### PR TITLE
Do not limit permutations for ios theme.

### DIFF
--- a/src/main/java/com/googlecode/mgwt/ui/client/theme/platform/Platform.gwt.xml
+++ b/src/main/java/com/googlecode/mgwt/ui/client/theme/platform/Platform.gwt.xml
@@ -28,10 +28,6 @@ under the License.
     return "ios";
     ]]></property-provider>
 
-  <set-property name="mgwt.density" value="xhigh" >
-    <when-property-is name="mgwt.os" value="ios" />
-  </set-property>
-    
   <inherits name="com.googlecode.mgwt.ui.client.theme.platform.main.MainResource" />
   <inherits name="com.googlecode.mgwt.ui.client.theme.platform.button.Button" />
   <inherits name="com.googlecode.mgwt.ui.client.theme.platform.buttonbar.ButtonBar" />


### PR DESCRIPTION
Limiting the permutation for iOS theme causes the desktop
browser to load a non existing permutation.
