### PR TITLE
Fixed display of progress indicator

### DIFF
--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/pull/PullArrowBaseAppearance.ui.xml
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/pull/PullArrowBaseAppearance.ui.xml
@@ -6,7 +6,9 @@
 	
    <g:FlowPanel ui:field="main" styleName="{appearance.css.pullToRefresh}">
         <g:FlowPanel ui:field="icon" styleName="{appearance.css.arrow}"/>
-		<mgwt:progress.ProgressIndicator ui:field="indicator" styleName="{appearance.css.spinner}" />     
+        <g:FlowPanel styleName="{appearance.css.spinner}">
+            <mgwt:progress.ProgressIndicator ui:field="indicator"/>
+        </g:FlowPanel>
      <g:HTML ui:field="textContainer" styleName="{appearance.css.text}" />
    
    </g:FlowPanel>


### PR DESCRIPTION
After last changes in progress indicator appearance, pull panel widget does not display the progress indicator during refresh. This is a simple fix. (Issue #108 )
