### PR TITLE
Only let ScrollPanel fire move events if direction can actually scroll.

### DIFF
--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/scroll/impl/ScrollPanelTouchImpl.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/scroll/impl/ScrollPanelTouchImpl.java
@@ -1697,12 +1697,12 @@ public class ScrollPanelTouchImpl extends ScrollPanelImpl {
   }
 
   private native int getMouseWheelVelocityX(NativeEvent evt)/*-{
-		return Math.round(-evt.wheelDeltaX) || 0;
+		return Math.round(evt.wheelDeltaX) || 0;
   }-*/;
 
   private native int getMouseWheelVelocityY(NativeEvent evt)/*-{
 
-		var val = (evt.detail * 40) || -evt.wheelDeltaY || 0;
+		var val = (evt.detail * 40) || evt.wheelDeltaY || 0;
 		return Math.round(val);
   }-*/;
 


### PR DESCRIPTION
fixes #9
