### PR TITLE
Disable use of mask image for android < 4.4

### DIFF
--- a/src/main/java/com/googlecode/mgwt/ui/client/util/IconHandler.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/util/IconHandler.java
@@ -25,6 +25,14 @@ import com.googlecode.mgwt.ui.client.MGWT;
 
 public class IconHandler {
 
+  static {
+    if (MGWT.getOsDetection().isAndroid4_3_orLower()) {
+      ICON_HANDLER = new IconHandlerEmulatedImpl();
+    } else {
+      ICON_HANDLER = GWT.create(IconHandlerImpl.class);
+    }
+  }
+
 
   private interface IconHandlerImpl {
     public void setIcons(Element element, ImageResource icon, String color);
@@ -72,8 +80,6 @@ public class IconHandler {
     }
   }
 
-  // Used with GWT.create
-  @SuppressWarnings("unused")
   private static class IconHandlerEmulatedImpl extends IconHandlerNativeImpl {
 
     private static final ImageConverter converter = new ImageConverter();
@@ -87,6 +93,8 @@ public class IconHandler {
       element.getStyle().setBackgroundColor("transparent");
       ImageResource convertImageResource = converter.convert(icon, color);
       Dimension dimensions = calculateDimensions(convertImageResource);
+      element.getStyle().setWidth(dimensions.width, Unit.PX);
+      element.getStyle().setHeight(dimensions.height, Unit.PX);
       element.getStyle().setBackgroundImage(
           "url(" + convertImageResource.getSafeUri().asString() + ")");
       element.getStyle().setProperty("backgroundSize",
@@ -94,7 +102,7 @@ public class IconHandler {
     }
   }
 
-  private static final IconHandlerImpl ICON_HANDLER = GWT.create(IconHandlerImpl.class);
+  private static final IconHandlerImpl ICON_HANDLER;
 
   public static void setIcons(Element element, ImageResource icon, String color) {
     ICON_HANDLER.setIcons(element, icon, color);

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/tabbar/TabBarButtonBase.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/tabbar/TabBarButtonBase.java
@@ -54,7 +54,7 @@ public class TabBarButtonBase extends ButtonBase {
     if (selected) {
       addStyleName(this.appearance.css().selected());
       if (selectedResource != null) {
-        IconHandler.setIcons(icon, selectedResource, appearance.css().BUTTON_BACKGROUND_COLOR());
+        IconHandler.setIcons(icon, selectedResource, appearance.css().BUTTON_BACKGROUND_HIGHLIGHT_COLOR());
       }
     } else {
       removeStyleName(this.appearance.css().selected());


### PR DESCRIPTION
The use of mask images and animations caused
older android devices to only display rectangles
instead of the actual shape. By switching to the
emulation implementation we avoid this.

fixes #160
