### PR TITLE
Add HasText to the implemented interfaces of MValueBoxBase

### DIFF
--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/base/MValueBoxBase.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/base/MValueBoxBase.java
@@ -44,6 +44,7 @@ import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HasEnabled;
 import com.google.gwt.user.client.ui.HasName;
+import com.google.gwt.user.client.ui.HasText;
 import com.google.gwt.user.client.ui.HasValue;
 import com.google.gwt.user.client.ui.ValueBoxBase;
 import com.google.gwt.user.client.ui.ValueBoxBase.TextAlignment;
@@ -66,7 +67,7 @@ import java.text.ParseException;
 public class MValueBoxBase<T> extends Composite implements AutoDirectionHandler.Target,
     HasAllKeyHandlers, HasAutoCapitalize, HasAutoCorrect, HasBlurHandlers, HasChangeHandlers,
     HasDirectionEstimator, HasEnabled, HasFocusHandlers, HasName, HasPlaceHolder, HasTouchHandlers,
-    HasValue<T>, IsEditor<ValueBoxEditor<T>> {
+    HasText, HasValue<T>, IsEditor<ValueBoxEditor<T>> {
 
   public interface HasSource {
     public void setSource(Object source);
@@ -254,6 +255,7 @@ public class MValueBoxBase<T> extends Composite implements AutoDirectionHandler.
     box.setSelectionRange(pos, length);
   }
 
+  @Override
   public void setText(String text) {
     box.setText(text);
   }


### PR DESCRIPTION
This restores compatibility with GWT 2.6, where HasText came from AutoDirectionHandler.Target.

Note that this reverts 3fd1752fb34429f43637fc29c577d1a75a1d6f7a again.

GWT commit 63a0336368c7439f1fb55563f507d7e232ee3360 readded the #setText() method in AutoDirectionHandler.Target, so 3fd1752fb34429f43637fc29c577d1a75a1d6f7a is no longer needed.

```
Author: Colin Alworth <niloc132@gmail.com>
Date:   Fri Oct 10 17:16:16 2014 -0500

    Fixed API break in AutoDirectionHandler.Target

    As part of the GWT module breakup for modular compilation, the I18n
    module was updated to not depend on User. This involved changing
    AutoDirectionHandler.Target to no longer depend on HasText. While
    the getText() method was added in the initial patch, this left
    Target subclasses with an @Override'd setText broken. This patch
    allows implementors of Target that are compatible with GWT <=2.6 to
    build with 2.7.

    See fc1babac93730ec48fe5d56d6c22b3657db9e68a for the original change.

    Change-Id: I7f3e62b590153dd3fd4a9de89c2b7b05628bb260

```

But still that change doesn't fix the part of changed interfaces here, previously the various input boxes such as MEmailTextBox would implement HasText, and now they don't. As MValueBoxBase should mirror ValueBoxBase, and that one has HasText explicitly it seems easiest to just do that here as well.
