### PR TITLE
Fix MainResourceAppearance in platform themes

### DIFF
--- a/src/main/java/com/googlecode/mgwt/ui/client/theme/platform/main/MainResource.gwt.xml
+++ b/src/main/java/com/googlecode/mgwt/ui/client/theme/platform/main/MainResource.gwt.xml
@@ -14,6 +14,6 @@ under the License.
 
 <module>
   <replace-with class="com.googlecode.mgwt.ui.client.theme.platform.main.MainResourceAppearancePlatform">
-    <when-type-is class="com.googlecode.mgwt.ui.client.resource.MainResourceAppearance" />
+    <when-type-is class="com.googlecode.mgwt.ui.client.widget.main.MainResourceAppearance" />
   </replace-with>
 </module>


### PR DESCRIPTION
Fixed the wrong package name so deferred binding of MainResourceAppearance works correctly when using platform theme.
