### PR TITLE
Windows Phone 8/8.1 support (desktop ie10/11 and mobile ie10/11 supported)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.googlecode.mgwt</groupId>
-  <artifactId>mgwt</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <artifactId>kirona-mgwt</artifactId>
+  <version>2.0.2</version>
   <packaging>jar</packaging>
   <name>mgwt</name>
 
   <properties>
-    <gwtversion>2.6.1</gwtversion>
+    <gwtversion>2.7.0</gwtversion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -127,7 +127,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>2.6.1</version>
+        <version>2.7.0</version>
         <executions>
           <execution>
             <goals>

--- a/src/main/java/com/google/gwt/user/client/impl/DOMImplIE10.java
+++ b/src/main/java/com/google/gwt/user/client/impl/DOMImplIE10.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.user.client.impl;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+
+/**
+ * IE10 implementation of {@link com.google.gwt.user.client.impl.DOMImplStandard}.
+ */
+public class DOMImplIE10 extends DOMImplIE9 {
+  
+  static
+  {
+    DOMImplStandard.addCaptureEventDispatchers(getCaptureEventDispatchers());
+    DOMImplStandard.addBitlessEventDispatchers(getBitlessEventDispatchers());
+  }
+
+  public static native JavaScriptObject getCaptureEventDispatchers() /*-{
+    return {
+      MSPointerDown:   @com.google.gwt.user.client.impl.DOMImplStandard::dispatchCapturedMouseEvent(*),
+      MSPointerUp:     @com.google.gwt.user.client.impl.DOMImplStandard::dispatchCapturedMouseEvent(*),
+      MSPointerMove:   @com.google.gwt.user.client.impl.DOMImplStandard::dispatchCapturedMouseEvent(*),
+      MSPointerCancel: @com.google.gwt.user.client.impl.DOMImplStandard::dispatchCapturedMouseEvent(*)
+    };
+  }-*/;
+
+  public static native JavaScriptObject getBitlessEventDispatchers() /*-{
+    return {
+      MSPointerDown:   @com.google.gwt.user.client.impl.DOMImplStandard::dispatchEvent(*),
+      MSPointerUp:     @com.google.gwt.user.client.impl.DOMImplStandard::dispatchEvent(*),
+      MSPointerMove:   @com.google.gwt.user.client.impl.DOMImplStandard::dispatchEvent(*),
+      MSPointerCancel: @com.google.gwt.user.client.impl.DOMImplStandard::dispatchEvent(*)
+    };
+  }-*/;
+
+}

--- a/src/main/java/com/google/gwt/user/client/impl/DOMImplIE10.java
+++ b/src/main/java/com/google/gwt/user/client/impl/DOMImplIE10.java
@@ -16,7 +16,6 @@
 package com.google.gwt.user.client.impl;
 
 import com.google.gwt.core.client.JavaScriptObject;
-import com.googlecode.mgwt.ui.client.MGWT;
 
 
 /**
@@ -28,41 +27,24 @@ public class DOMImplIE10 extends DOMImplIE9 {
   {
     DOMImplStandard.addCaptureEventDispatchers(getCaptureEventDispatchers());
     DOMImplStandard.addBitlessEventDispatchers(getBitlessEventDispatchers());
-    if (MGWT.getOsDetection().isWindowsPhone()) {
-      capturePointerEvents();
-    }
-    else {
-      // for desktop we need a focus fix
-      capturePointerEventsWithFocusFix();
-    }
+    capturePointerEvents();
   }
   
   /**
    * Lets have the same behaviour as IOS where the target element continues to receive Pointer events
-   * even when the pointer has moved off the element up until MSPointerUp has occurred. 
+   * even when the pointer has moved off the element up until MSPointerUp has occurred.
+   * 
+   *  Do not do pointer capture on input or textarea elements, all sorts of problems arise if you do!
    */
   private native static void capturePointerEvents() /*-{
-    $wnd.addEventListener('MSPointerDown',
-      function(evt) {
-        evt.target.msSetPointerCapture(evt.pointerId);
-      }, true);
+      $wnd.addEventListener('MSPointerDown',
+        $entry(function(evt) {
+          if ((evt.target.tagName !== 'INPUT') && (evt.target.tagName !== 'TEXTAREA'))  {
+            evt.target.msSetPointerCapture(evt.pointerId);
+          }
+        }), true);
   }-*/;
 
-  /**
-   * On desktop, for some reason when you do pointer capture input elements fail to get the focus
-   */
-  private native static void capturePointerEventsWithFocusFix() /*-{
-    var getFocus = function(evt) {
-      this.focus()
-    };
-    $wnd.addEventListener('MSPointerDown',
-      function(evt) {
-        evt.target.msSetPointerCapture(evt.pointerId);
-        if (evt.target.focus) {
-          evt.target.addEventListener('MSPointerUp',getFocus);
-        }
-      }, true);
-  }-*/;
   
   public static native JavaScriptObject getCaptureEventDispatchers() /*-{
     return {

--- a/src/main/java/com/google/gwt/user/client/impl/DOMImplIE10.java
+++ b/src/main/java/com/google/gwt/user/client/impl/DOMImplIE10.java
@@ -25,9 +25,18 @@ public class DOMImplIE10 extends DOMImplIE9 {
   
   static
   {
-    DOMImplStandard.addCaptureEventDispatchers(getCaptureEventDispatchers());
+    //DOMImplStandard.addCaptureEventDispatchers(getCaptureEventDispa
     DOMImplStandard.addBitlessEventDispatchers(getBitlessEventDispatchers());
+    capturePointerEvents();
   }
+  
+  /**
+   * Lets have the same behaviour as IOS where the target element continues to receive pointer events
+   * even when the pointer has moved off the element up until pointer up has occured
+   */
+  private native static void capturePointerEvents() /*-{
+    $wnd.addEventListener('MSPointerDown',function(evt){evt.target.msSetPointerCapture(evt.pointerId);}, true);
+  }-*/;
 
   public static native JavaScriptObject getCaptureEventDispatchers() /*-{
     return {

--- a/src/main/java/com/google/gwt/useragent/rebind/UserAgentPropertyGenerator.java
+++ b/src/main/java/com/google/gwt/useragent/rebind/UserAgentPropertyGenerator.java
@@ -26,11 +26,9 @@ public class UserAgentPropertyGenerator implements PropertyProviderGenerator {
    * ensures we never choose them for IE11 (we know that they will not work for IE11).
    */
   private enum UserAgent {
-    safari("return (ua.indexOf('webkit') != -1);"),
+    safari("return ((ua.indexOf('webkit') != -1) && !(ua.indexOf('trident') != -1));"),
     ie10("return (ua.indexOf('msie') != -1 && (docMode >= 10 && docMode < 11)) || "
-              + "(ua.indexOf('iemobile') != -1 && (docMode >= 10 && docMode < 11)) || "
-              + "(ua.indexOf('msie') != -1 && (docMode >= 11 && docMode < 12)) || "
-              + "(ua.indexOf('iemobile') != -1 && (docMode >= 11 && docMode < 12));"),
+              + "(ua.indexOf('iemobile') != -1 && (docMode >= 10 && docMode < 11))"),
     ie9("return (ua.indexOf('msie') != -1 && (docMode >= 9 && docMode < 11));"),
     ie8("return (ua.indexOf('msie') != -1 && (docMode >= 8 && docMode < 11));"),
     gecko1_8("return (ua.indexOf('gecko') != -1 || docMode >= 11);");

--- a/src/main/java/com/google/gwt/useragent/rebind/UserAgentPropertyGenerator.java
+++ b/src/main/java/com/google/gwt/useragent/rebind/UserAgentPropertyGenerator.java
@@ -1,0 +1,106 @@
+
+package com.google.gwt.useragent.rebind;
+
+import com.google.gwt.core.ext.TreeLogger;
+import com.google.gwt.core.ext.linker.ConfigurationProperty;
+import com.google.gwt.core.ext.linker.PropertyProviderGenerator;
+import com.google.gwt.user.rebind.SourceWriter;
+import com.google.gwt.user.rebind.StringSourceWriter;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.SortedSet;
+
+/**
+ * Generator which writes out the JavaScript for determining the value of the
+ * <code>user.agent</code> selection property.
+ */
+public class UserAgentPropertyGenerator implements PropertyProviderGenerator {
+
+  /**
+   * The list of {@code user.agent} values listed here should be kept in sync with
+   * {@code UserAgent.gwt.xml}.
+   * <p>Note that the order of enums matter as the script selection is based on running
+   * these predicates in order and matching the first one that returns {@code true}.
+   * <p> Also note that, {@code docMode < 11} in predicates for older IEs exists to
+   * ensures we never choose them for IE11 (we know that they will not work for IE11).
+   */
+  private enum UserAgent {
+    safari("return (ua.indexOf('webkit') != -1);"),
+    ie10("return (ua.indexOf('msie') != -1 && (docMode >= 10 && docMode < 11)) || "
+              + "(ua.indexOf('iemobile') != -1 && (docMode >= 10 && docMode < 11)) || "
+              + "(ua.indexOf('msie') != -1 && (docMode >= 11 && docMode < 12)) || "
+              + "(ua.indexOf('iemobile') != -1 && (docMode >= 11 && docMode < 12));"),
+    ie9("return (ua.indexOf('msie') != -1 && (docMode >= 9 && docMode < 11));"),
+    ie8("return (ua.indexOf('msie') != -1 && (docMode >= 8 && docMode < 11));"),
+    gecko1_8("return (ua.indexOf('gecko') != -1 || docMode >= 11);");
+
+    private final String predicateBlock;
+
+    private UserAgent(String predicateBlock) {
+      this.predicateBlock = predicateBlock;
+    }
+
+    private static Set<String> getKnownAgents() {
+      HashSet<String> userAgents = new HashSet<String>();
+      for (UserAgent userAgent : values()) {
+        userAgents.add(userAgent.name());
+      }
+      return userAgents;
+    }
+  }
+
+  /**
+   * Writes out the JavaScript function body for determining the value of the
+   * <code>user.agent</code> selection property. This method is used to create
+   * the selection script and by {@link UserAgentGenerator} to assert at runtime
+   * that the correct user agent permutation is executing.
+   */
+  static void writeUserAgentPropertyJavaScript(SourceWriter body,
+      SortedSet<String> possibleValues, String fallback) {
+
+    // write preamble
+    body.println("var ua = navigator.userAgent.toLowerCase();");
+    body.println("var docMode = $doc.documentMode;");
+
+    for (UserAgent userAgent : UserAgent.values()) {
+      // write only selected user agents
+      if (possibleValues.contains(userAgent.name())) {
+        body.println("if ((function() { ");
+        body.indentln(userAgent.predicateBlock);
+        body.println("})()) return '%s';", userAgent.name());
+      }
+    }
+
+    // default return
+    if (fallback == null) {
+      fallback = "unknown";
+    }
+    body.println("return '" + fallback + "';");
+  }
+
+  @Override
+  public String generate(TreeLogger logger, SortedSet<String> possibleValues, String fallback,
+      SortedSet<ConfigurationProperty> configProperties) {
+    assertUserAgents(logger, possibleValues);
+
+    StringSourceWriter body = new StringSourceWriter();
+    body.println("{");
+    body.indent();
+    writeUserAgentPropertyJavaScript(body, possibleValues, fallback);
+    body.outdent();
+    body.println("}");
+
+    return body.toString();
+  }
+
+  private static void assertUserAgents(TreeLogger logger, SortedSet<String> possibleValues) {
+    HashSet<String> unknownValues = new HashSet<String>(possibleValues);
+    unknownValues.removeAll(UserAgent.getKnownAgents());
+    if (!unknownValues.isEmpty()) {
+      logger.log(TreeLogger.WARN, "Unrecognized " + UserAgentGenerator.PROPERTY_USER_AGENT
+          + " values " + unknownValues + ", possibly due to UserAgent.gwt.xml and "
+          + UserAgentPropertyGenerator.class.getName() + " being out of sync.");
+    }
+  }
+}

--- a/src/main/java/com/googlecode/mgwt/dom/DOM.gwt.xml
+++ b/src/main/java/com/googlecode/mgwt/dom/DOM.gwt.xml
@@ -50,6 +50,8 @@
 	    }else{
 	      return "tablet";
 	    }
+      } else if (ua.indexOf("windows phone 8") != -1) {
+        return "phone";
       }
       
       // Everything else is a desktop.
@@ -78,4 +80,19 @@
     <replace-with class="com.googlecode.mgwt.dom.client.recognizer.EventPropagatorMobileImpl">
         <when-type-is class="com.googlecode.mgwt.dom.client.recognizer.EventPropagator"/>
     </replace-with>
+
+    <replace-with class="com.googlecode.mgwt.dom.client.recognizer.EventPropagatorStandardImpl">
+        <when-type-is class="com.googlecode.mgwt.dom.client.recognizer.EventPropagator"/>
+        <all>
+            <when-property-is name="user.agent" value="ie10" />
+        </all>
+    </replace-with>
+
+    <replace-with class="com.google.gwt.user.client.impl.DOMImplIE10">
+        <when-type-is class="com.google.gwt.user.client.impl.DOMImpl"/>
+        <all>
+            <when-property-is name="user.agent" value="ie10"/>
+        </all>
+    </replace-with>
+    
 </module>

--- a/src/main/java/com/googlecode/mgwt/dom/DOM.gwt.xml
+++ b/src/main/java/com/googlecode/mgwt/dom/DOM.gwt.xml
@@ -38,7 +38,10 @@
 
       // Detect form factor from user agent.
       var ua = navigator.userAgent.toLowerCase();
-      if (ua.indexOf("iphone") != -1 || ua.indexOf("ipod") != -1) {
+      if (ua.indexOf("windows phone 8") != -1) {
+        // windows phone 8/8.1
+        return "phone";
+      } else if (ua.indexOf("iphone") != -1 || ua.indexOf("ipod") != -1) {
         // iphone and ipod.
         return "phone";
       } else if (ua.indexOf("ipad") != -1) {
@@ -50,8 +53,6 @@
 	    }else{
 	      return "tablet";
 	    }
-      } else if (ua.indexOf("windows phone 8") != -1) {
-        return "phone";
       }
       
       // Everything else is a desktop.
@@ -59,6 +60,14 @@
     ]]></property-provider>
     <define-property name="mgwt.density" values="mid, high, xhigh" />
     <property-provider name="mgwt.density"><![CDATA[
+        if (!window.devicePixelRatio) {
+          try {
+            if ('deviceXDPI' in screen) {
+              window.devicePixelRatio = screen.deviceXDPI / screen.logicalXDPI;
+            }
+          }
+          catch(e) {}
+        }
         if (!window.devicePixelRatio) {
           return 'mid';
         }

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/MsPointerCancelEvent.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/MsPointerCancelEvent.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.mgwt.dom.client.event.pointer;
+
+import com.google.gwt.event.dom.client.DomEvent;
+
+/**
+ * Represents a native MsPointerCancelEvent.
+ */
+public class MsPointerCancelEvent extends MsPointerEvent<MsPointerCancelHandler> {
+
+  /**
+   * Event type for MsPointerCancelEvent. Represents the meta-data associated with
+   * this event.
+   */
+  private static final Type<MsPointerCancelHandler> TYPE = new Type<MsPointerCancelHandler>(
+      MsPointerEvent.MSPOINTERCANCEL, new MsPointerCancelEvent());
+
+  /**
+   * Gets the event type associated with pointer cancel events.
+   *
+   * @return the handler type
+   */
+  public static Type<MsPointerCancelHandler> getType() {
+    return TYPE;
+  }
+
+  /**
+   * Protected constructor, use
+   * {@link DomEvent#fireNativeEvent(com.google.gwt.dom.client.NativeEvent, com.google.gwt.event.shared.HasHandlers)}
+   * to fire pointer up events.
+   */
+  protected MsPointerCancelEvent() {
+  }
+
+  @Override
+  public final Type<MsPointerCancelHandler> getAssociatedType() {
+    return TYPE;
+  }
+
+  @Override
+  protected void dispatch(MsPointerCancelHandler handler) {
+    handler.onPointerCancel(this);
+  }
+
+}

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/MsPointerCancelHandler.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/MsPointerCancelHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.mgwt.dom.client.event.pointer;
+
+import com.google.gwt.event.shared.EventHandler;
+
+/**
+ * Handler interface for {@link MsPointerCancelEvent} events.
+ */
+public interface MsPointerCancelHandler extends EventHandler {
+
+  /**
+   * Called when MsPointerCancelEvent is fired.
+   *
+   * @param event the {@link MsPointerCancelEvent} that was fired
+   */
+  void onPointerCancel(MsPointerCancelEvent event);
+}

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/MsPointerDownEvent.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/MsPointerDownEvent.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.mgwt.dom.client.event.pointer;
+
+import com.google.gwt.event.dom.client.DomEvent;
+
+/**
+ * Represents a native MsPointerDownEvent.
+ */
+public class MsPointerDownEvent extends MsPointerEvent<MsPointerDownHandler> {
+
+  /**
+   * Event type for MsPointerDownEvent. Represents the meta-data associated with
+   * this event.
+   */
+  private static final Type<MsPointerDownHandler> TYPE = new Type<MsPointerDownHandler>(
+      MsPointerEvent.MSPOINTERDOWN, new MsPointerDownEvent());
+
+  /**
+   * Gets the event type associated with MsPointerDownEvent events.
+   *
+   * @return the handler type
+   */
+  public static Type<MsPointerDownHandler> getType() {
+    return TYPE;
+  }
+
+  /**
+   * Protected constructor, use
+   * {@link DomEvent#fireNativeEvent(com.google.gwt.dom.client.NativeEvent, com.google.gwt.event.shared.HasHandlers)}
+   * to fire pointer down events.
+   */
+  protected MsPointerDownEvent() {
+  }
+
+  @Override
+  public final Type<MsPointerDownHandler> getAssociatedType() {
+    return TYPE;
+  }
+
+  @Override
+  protected void dispatch(MsPointerDownHandler handler) {
+    handler.onPointerDown(this);
+  }
+
+}

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/MsPointerDownHandler.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/MsPointerDownHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.mgwt.dom.client.event.pointer;
+
+import com.google.gwt.event.shared.EventHandler;
+
+/**
+ * Handler interface for {@link MsPointerDownEvent} events.
+ */
+public interface MsPointerDownHandler extends EventHandler {
+
+  /**
+   * Called when MsPointerDownEvent is fired.
+   *
+   * @param event the {@link MsPointerDownEvent} that was fired
+   */
+  void onPointerDown(MsPointerDownEvent event);
+}

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/MsPointerEvent.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/MsPointerEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.mgwt.dom.client.event.pointer;
+
+import com.google.gwt.event.dom.client.MouseEvent;
+import com.google.gwt.event.shared.EventHandler;
+
+/**
+ * Abstract class representing MsPointer events.
+ *
+ * @param <H> handler type
+ *
+ */
+public abstract class MsPointerEvent<H extends EventHandler> extends MouseEvent<H> {
+
+  public static final String MSPOINTERDOWN = "MSPointerDown";
+  public static final String MSPOINTERMOVE = "MSPointerMove";
+  public static final String MSPOINTEROUT = "MSPointerOut";
+  public static final String MSPOINTEROVER = "MSPointerOver";
+  public static final String MSPOINTERUP = "MSPointerUp";
+  public static final String MSPOINTERCANCEL = "MSPointerCancel";
+
+  public final native int getPointerId() /*-{
+    var e = this.@com.google.gwt.event.dom.client.DomEvent::nativeEvent;
+    return e.pointerId;
+  }-*/;
+
+}

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/MsPointerMoveEvent.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/MsPointerMoveEvent.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.mgwt.dom.client.event.pointer;
+
+import com.google.gwt.event.dom.client.DomEvent;
+
+/**
+ * Represents a native MsPointerMoveEvent event.
+ */
+public class MsPointerMoveEvent extends MsPointerEvent<MsPointerMoveHandler> {
+
+  /**
+   * Event type for MsPointerMoveEvent. Represents the meta-data associated with
+   * this event.
+   */
+  private static final Type<MsPointerMoveHandler> TYPE = new Type<MsPointerMoveHandler>(
+      MsPointerEvent.MSPOINTERMOVE, new MsPointerMoveEvent());
+
+  /**
+   * Gets the event type associated with MsPointerMoveEvent.
+   *
+   * @return the handler type
+   */
+  public static Type<MsPointerMoveHandler> getType() {
+    return TYPE;
+  }
+
+  /**
+   * Protected constructor, use
+   * {@link DomEvent#fireNativeEvent(com.google.gwt.dom.client.NativeEvent, com.google.gwt.event.shared.HasHandlers)}
+   * to fire pointer down events.
+   */
+  protected MsPointerMoveEvent() {
+  }
+
+  @Override
+  public final Type<MsPointerMoveHandler> getAssociatedType() {
+    return TYPE;
+  }
+
+  @Override
+  protected void dispatch(MsPointerMoveHandler handler) {
+    handler.onPointerMove(this);
+  }
+
+}

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/MsPointerMoveHandler.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/MsPointerMoveHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.mgwt.dom.client.event.pointer;
+
+import com.google.gwt.event.shared.EventHandler;
+
+/**
+ * Handler interface for {@link MsPointerMoveEvent} events.
+ */
+public interface MsPointerMoveHandler extends EventHandler {
+
+  /**
+   * Called when MsPointerMoveEvent is fired.
+   *
+   * @param event the {@link MsPointerMoveEvent} that was fired
+   */
+  void onPointerMove(MsPointerMoveEvent event);
+}

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/MsPointerUpEvent.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/MsPointerUpEvent.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.mgwt.dom.client.event.pointer;
+
+import com.google.gwt.event.dom.client.DomEvent;
+
+/**
+ * Represents a native MsPointerUpEvent.
+ */
+public class MsPointerUpEvent extends MsPointerEvent<MsPointerUpHandler> {
+
+  /**
+   * Event type for MsPointerUpEvent. Represents the meta-data associated with
+   * this event.
+   */
+  private static final Type<MsPointerUpHandler> TYPE = new Type<MsPointerUpHandler>(
+      MsPointerEvent.MSPOINTERUP, new MsPointerUpEvent());
+
+  /**
+   * Gets the event type associated with MsPointerUpEvent.
+   *
+   * @return the handler type
+   */
+  public static Type<MsPointerUpHandler> getType() {
+    return TYPE;
+  }
+
+  /**
+   * Protected constructor, use
+   * {@link DomEvent#fireNativeEvent(com.google.gwt.dom.client.NativeEvent, com.google.gwt.event.shared.HasHandlers)}
+   * to fire pointer down events.
+   */
+  protected MsPointerUpEvent() {
+  }
+
+  @Override
+  public final Type<MsPointerUpHandler> getAssociatedType() {
+    return TYPE;
+  }
+
+  @Override
+  protected void dispatch(MsPointerUpHandler handler) {
+    handler.onPointerUp(this);
+  }
+
+}

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/MsPointerUpHandler.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/MsPointerUpHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.mgwt.dom.client.event.pointer;
+
+import com.google.gwt.event.shared.EventHandler;
+
+/**
+ * Handler interface for {@link MsPointerUpEvent} events.
+ */
+public interface MsPointerUpHandler extends EventHandler {
+
+  /**
+   * Called when MsPointerUpEvent is fired.
+   *
+   * @param event the {@link MsPointerUpEvent} that was fired
+   */
+  void onPointerUp(MsPointerUpEvent event);
+}

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/SimulatedTouch.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/SimulatedTouch.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014 Daniel Kurka
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.mgwt.dom.client.event.pointer;
+
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.dom.client.Touch;
+
+public class SimulatedTouch extends Touch {
+
+  public static native SimulatedTouch createTouch() /*-{
+    // need to native for GwtMockito to work
+    return {};
+  }-*/;
+
+  public native static JsArray<Touch> createTouchArray() /*-{
+    return [];
+  }-*/;
+
+  protected SimulatedTouch() {
+  }
+
+  public final native void setClientX(int clientX) /*-{
+    this.clientX = clientX;
+  }-*/;
+
+  public final native void setClientY(int clientY) /*-{
+    this.clientY = clientY;
+  }-*/;
+
+  public final native void setPageX(int pageX) /*-{
+    this.pageX = pageX;
+  }-*/;
+
+  public final native void setPageY(int pageY) /*-{
+    this.pageY = pageY;
+  }-*/;
+
+  public final native void setScreenX(int screenX) /*-{
+    this.screenX = screenX;
+  }-*/;
+
+  public final native void setScreenY(int screenY) /*-{
+    this.screenY = screenY;
+  }-*/;
+
+  public final native void setId(int touchId) /*-{
+    this.identifier = touchId
+  }-*/;
+}

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/SimulatedTouchCancelEvent.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/SimulatedTouchCancelEvent.java
@@ -1,0 +1,12 @@
+package com.googlecode.mgwt.dom.client.event.pointer;
+
+import com.google.gwt.event.dom.client.TouchCancelEvent;
+
+public class SimulatedTouchCancelEvent extends TouchCancelEvent
+{
+  public SimulatedTouchCancelEvent(MsPointerCancelEvent event) {
+    setNativeEvent(event.getNativeEvent());
+    setSource(event.getSource());
+  }
+
+}

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/SimulatedTouchEndEvent.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/SimulatedTouchEndEvent.java
@@ -31,17 +31,17 @@ public class SimulatedTouchEndEvent extends TouchEndEvent {
   /**
    * Construct a simulated TouchEndEvent from a {@link MsPointerUpEvent}
    * 
-   * @param pointerUpEvent the data for the simulated event;
+   * @param event the data for the simulated event;
    * @param multiTouch
    */
-  public SimulatedTouchEndEvent(MsPointerUpEvent pointerUpEvent, int touchId) {
-    clientX = pointerUpEvent.getClientX();
-    clientY = pointerUpEvent.getClientY();
-    this.touchId = touchId;
-    pageX = pointerUpEvent.getScreenX();
-    pageY = pointerUpEvent.getScreenY();
-    setNativeEvent(pointerUpEvent.getNativeEvent());
-    setSource(pointerUpEvent.getSource());
+  public SimulatedTouchEndEvent(MsPointerUpEvent event) {
+    this.touchId = event.getPointerId();
+    clientX = event.getClientX();
+    clientY = event.getClientY();
+    pageX = event.getScreenX();
+    pageY = event.getScreenY();
+    setNativeEvent(event.getNativeEvent());
+    setSource(event.getSource());
   }
 
   @Override

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/SimulatedTouchEndEvent.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/SimulatedTouchEndEvent.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2010 Daniel Kurka
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.mgwt.dom.client.event.pointer;
+
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.dom.client.Touch;
+import com.google.gwt.event.dom.client.TouchEndEvent;
+
+/**
+ * A simulated TouchEndEvent is really a MsPointerUpEvent
+ */
+public class SimulatedTouchEndEvent extends TouchEndEvent {
+
+  private final int clientX;
+  private final int clientY;
+  private final int pageX;
+  private final int pageY;
+  private int touchId;
+
+  /**
+   * Construct a simulated TouchEndEvent from a {@link MsPointerUpEvent}
+   * 
+   * @param pointerUpEvent the data for the simulated event;
+   * @param multiTouch
+   */
+  public SimulatedTouchEndEvent(MsPointerUpEvent pointerUpEvent, int touchId) {
+    clientX = pointerUpEvent.getClientX();
+    clientY = pointerUpEvent.getClientY();
+    this.touchId = touchId;
+    pageX = pointerUpEvent.getScreenX();
+    pageY = pointerUpEvent.getScreenY();
+    setNativeEvent(pointerUpEvent.getNativeEvent());
+    setSource(pointerUpEvent.getSource());
+  }
+
+  @Override
+  public JsArray<Touch> getChangedTouches() {
+    JsArray<Touch> array = SimulatedTouch.createTouchArray();
+    SimulatedTouch touch = SimulatedTouch.createTouch();
+    touch.setClientX(clientX);
+    touch.setClientY(clientY);
+    touch.setPageX(pageX);
+    touch.setPageY(pageY);
+    touch.setId(touchId);
+    array.push(touch);
+    return array;
+  }
+
+  @Override
+  public JsArray<Touch> getTouches() {
+    return SimulatedTouch.createTouchArray();
+  }
+
+}

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/SimulatedTouchMoveEvent.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/SimulatedTouchMoveEvent.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2010 Daniel Kurka
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.mgwt.dom.client.event.pointer;
+
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.dom.client.Touch;
+import com.google.gwt.event.dom.client.TouchMoveEvent;
+
+/**
+ * A simulated TouchMoveEvent is really a MS Pointer move event
+ */
+public class SimulatedTouchMoveEvent extends TouchMoveEvent {
+
+  private final int clientX;
+  private final int clientY;
+  private final int pageX;
+  private final int pageY;
+  private int touchId;
+
+  public SimulatedTouchMoveEvent(MsPointerMoveEvent event, int touchId) {
+    this.touchId = touchId;
+    clientX = event.getClientX();
+    clientY = event.getClientY();
+    pageX = event.getScreenX();
+    pageY = event.getScreenY();
+    setNativeEvent(event.getNativeEvent());
+    setSource(event.getSource());
+  }
+
+  @Override
+  public JsArray<Touch> getChangedTouches() {
+    JsArray<Touch> array = SimulatedTouch.createTouchArray();
+    SimulatedTouch touch = SimulatedTouch.createTouch();
+    touch.setClientX(clientX);
+    touch.setClientY(clientY);
+    touch.setPageX(pageX);
+    touch.setPageY(pageY);
+    touch.setId(touchId);
+    array.push(touch);
+    return array;
+  }
+
+  @Override
+  public JsArray<Touch> getTouches() {
+    JsArray<Touch> array = SimulatedTouch.createTouchArray();
+    SimulatedTouch touch = SimulatedTouch.createTouch();
+    touch.setClientX(clientX);
+    touch.setClientY(clientY);
+    touch.setPageX(pageX);
+    touch.setPageY(pageY);
+    touch.setId(touchId);
+    array.push(touch);
+    return array;
+  }
+}

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/SimulatedTouchMoveEvent.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/SimulatedTouchMoveEvent.java
@@ -28,8 +28,8 @@ public class SimulatedTouchMoveEvent extends TouchMoveEvent {
   private final int pageY;
   private int touchId;
 
-  public SimulatedTouchMoveEvent(MsPointerMoveEvent event, int touchId) {
-    this.touchId = touchId;
+  public SimulatedTouchMoveEvent(MsPointerMoveEvent event) {
+    this.touchId = event.getPointerId();
     clientX = event.getClientX();
     clientY = event.getClientY();
     pageX = event.getScreenX();

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/SimulatedTouchStartEvent.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/SimulatedTouchStartEvent.java
@@ -28,8 +28,8 @@ public class SimulatedTouchStartEvent extends TouchStartEvent {
   private final int pageY;
   private int touchId;
 
-  public SimulatedTouchStartEvent(MsPointerDownEvent event, int touchId) {
-    this.touchId = touchId;
+  public SimulatedTouchStartEvent(MsPointerDownEvent event) {
+    this.touchId = event.getPointerId();
     clientX = event.getClientX();
     clientY = event.getClientY();
     pageX = event.getScreenX();

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/SimulatedTouchStartEvent.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/SimulatedTouchStartEvent.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010 Daniel Kurka
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.mgwt.dom.client.event.pointer;
+
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.dom.client.Touch;
+import com.google.gwt.event.dom.client.TouchStartEvent;
+
+/**
+ * A simulated TouchStartEvent is really a MS Pointer down event
+ */
+public class SimulatedTouchStartEvent extends TouchStartEvent {
+  
+  private final int clientX;
+  private final int clientY;
+  private final int pageX;
+  private final int pageY;
+  private int touchId;
+
+  public SimulatedTouchStartEvent(MsPointerDownEvent event, int touchId) {
+    this.touchId = touchId;
+    clientX = event.getClientX();
+    clientY = event.getClientY();
+    pageX = event.getScreenX();
+    pageY = event.getScreenY();
+    setNativeEvent(event.getNativeEvent());
+    setSource(event.getSource());
+  }
+
+  @Override
+  public JsArray<Touch> getChangedTouches() {
+    JsArray<Touch> array = SimulatedTouch.createTouchArray();
+    SimulatedTouch touch = SimulatedTouch.createTouch();
+    touch.setClientX(clientX);
+    touch.setClientY(clientY);
+    touch.setPageX(pageX);
+    touch.setPageY(pageY);
+    touch.setId(touchId);
+    array.push(touch);
+    return array;
+  }
+
+  @Override
+  public JsArray<Touch> getTouches() {
+    JsArray<Touch> array = SimulatedTouch.createTouchArray();
+    SimulatedTouch touch = SimulatedTouch.createTouch();
+    touch.setClientX(clientX);
+    touch.setClientY(clientY);
+    touch.setPageX(pageX);
+    touch.setPageY(pageY);
+    touch.setId(touchId);
+    array.push(touch);
+    return array;
+  }
+
+}

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/TouchCancelToMsPointerCancelHandler.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/TouchCancelToMsPointerCancelHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2010 Daniel Kurka
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.mgwt.dom.client.event.pointer;
+
+import com.google.gwt.event.dom.client.TouchCancelHandler;
+
+/**
+ * Convert TouchCancelHandlers to MSPointer cancel handlers
+ */
+public class TouchCancelToMsPointerCancelHandler implements MsPointerCancelHandler {
+
+  private final TouchCancelHandler handler;
+
+  public TouchCancelToMsPointerCancelHandler(TouchCancelHandler handler) {
+    this.handler = handler;
+  }
+
+  @Override
+  public void onPointerCancel(MsPointerCancelEvent event) {
+      SimulatedTouchCancelEvent simulatedTouchCancelEvent = new SimulatedTouchCancelEvent(event);
+      handler.onTouchCancel(simulatedTouchCancelEvent);
+  }
+
+}

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/TouchEndToMsPointerUpHandler.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/TouchEndToMsPointerUpHandler.java
@@ -28,7 +28,7 @@ public class TouchEndToMsPointerUpHandler implements MsPointerUpHandler {
   /** {@inheritDoc} */
   @Override
   public void onPointerUp(MsPointerUpEvent event) {
-    SimulatedTouchEndEvent simulatedTouchEndEvent = new SimulatedTouchEndEvent(event, TouchStartToMsPointerDownHandler.lastTouchId);
+    SimulatedTouchEndEvent simulatedTouchEndEvent = new SimulatedTouchEndEvent(event);
     handler.onTouchEnd(simulatedTouchEndEvent);
   }
 

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/TouchEndToMsPointerUpHandler.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/TouchEndToMsPointerUpHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2010 Daniel Kurka
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.mgwt.dom.client.event.pointer;
+
+import com.google.gwt.event.dom.client.TouchEndHandler;
+
+/**
+ * Convert TouchEndHandlers to MsPointerUpHandlers
+ */
+public class TouchEndToMsPointerUpHandler implements MsPointerUpHandler {
+  private final TouchEndHandler handler;
+
+  public TouchEndToMsPointerUpHandler(TouchEndHandler handler) {
+    this.handler = handler;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void onPointerUp(MsPointerUpEvent event) {
+    SimulatedTouchEndEvent simulatedTouchEndEvent = new SimulatedTouchEndEvent(event, TouchStartToMsPointerDownHandler.lastTouchId);
+    handler.onTouchEnd(simulatedTouchEndEvent);
+  }
+
+}

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/TouchMoveToMsPointerMoveHandler.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/TouchMoveToMsPointerMoveHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2010 Daniel Kurka
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.mgwt.dom.client.event.pointer;
+
+import com.google.gwt.event.dom.client.TouchMoveHandler;
+
+/**
+ * Convert TouchMoveHandlers to MsPointerMoveHandlers for pointer devices
+ *
+ */
+public class TouchMoveToMsPointerMoveHandler implements MsPointerMoveHandler, MsPointerDownHandler, MsPointerUpHandler {
+
+  private boolean ignoreEvent;
+	private final TouchMoveHandler touchMoveHandler;
+
+	public TouchMoveToMsPointerMoveHandler(TouchMoveHandler touchMoveHandler) {
+		this.touchMoveHandler = touchMoveHandler;
+    ignoreEvent = true;
+	}
+
+	@Override
+  public void onPointerMove(MsPointerMoveEvent event) {
+    if (ignoreEvent)
+      return;
+		touchMoveHandler.onTouchMove(new SimulatedTouchMoveEvent(event, TouchStartToMsPointerDownHandler.lastTouchId));
+	}
+
+  @Override
+  public void onPointerUp(MsPointerUpEvent event)
+  {
+    ignoreEvent = true;
+  }
+
+  @Override
+  public void onPointerDown(MsPointerDownEvent event)
+  {
+    ignoreEvent = false;
+  }
+
+}

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/TouchMoveToMsPointerMoveHandler.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/TouchMoveToMsPointerMoveHandler.java
@@ -35,7 +35,7 @@ public class TouchMoveToMsPointerMoveHandler implements MsPointerMoveHandler, Ms
   public void onPointerMove(MsPointerMoveEvent event) {
     if (ignoreEvent)
       return;
-		touchMoveHandler.onTouchMove(new SimulatedTouchMoveEvent(event, TouchStartToMsPointerDownHandler.lastTouchId));
+		touchMoveHandler.onTouchMove(new SimulatedTouchMoveEvent(event));
 	}
 
   @Override

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/TouchStartToMsPointerDownHandler.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/TouchStartToMsPointerDownHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010 Daniel Kurka
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.googlecode.mgwt.dom.client.event.pointer;
+
+import com.google.gwt.event.dom.client.TouchStartHandler;
+
+/**
+ * Convert TouchStartHandlers to MSPointer down handlers
+ */
+public class TouchStartToMsPointerDownHandler implements MsPointerDownHandler {
+
+  private final TouchStartHandler handler;
+
+  public static int lastTouchId = 0;
+
+  public TouchStartToMsPointerDownHandler(TouchStartHandler handler) {
+    this.handler = handler;
+  }
+
+  @Override
+  public void onPointerDown(MsPointerDownEvent event) {
+    lastTouchId++;
+    SimulatedTouchStartEvent simulatedTouchStartEvent = new SimulatedTouchStartEvent(event, lastTouchId);
+    handler.onTouchStart(simulatedTouchStartEvent);
+  }
+
+}

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/TouchStartToMsPointerDownHandler.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/pointer/TouchStartToMsPointerDownHandler.java
@@ -22,16 +22,13 @@ public class TouchStartToMsPointerDownHandler implements MsPointerDownHandler {
 
   private final TouchStartHandler handler;
 
-  public static int lastTouchId = 0;
-
   public TouchStartToMsPointerDownHandler(TouchStartHandler handler) {
     this.handler = handler;
   }
 
   @Override
   public void onPointerDown(MsPointerDownEvent event) {
-    lastTouchId++;
-    SimulatedTouchStartEvent simulatedTouchStartEvent = new SimulatedTouchStartEvent(event, lastTouchId);
+    SimulatedTouchStartEvent simulatedTouchStartEvent = new SimulatedTouchStartEvent(event);
     handler.onTouchStart(simulatedTouchStartEvent);
   }
 

--- a/src/main/java/com/googlecode/mgwt/dom/client/event/tap/TapEvent.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/event/tap/TapEvent.java
@@ -16,6 +16,7 @@
 package com.googlecode.mgwt.dom.client.event.tap;
 
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Touch;
 import com.google.gwt.event.shared.GwtEvent;
 
 /**
@@ -28,16 +29,14 @@ import com.google.gwt.event.shared.GwtEvent;
 public class TapEvent extends GwtEvent<TapHandler> {
 
 	private static final Type<TapHandler> TYPE = new Type<TapHandler>();
-	private final int startX;
-	private final int startY;
+	private final Touch touch;
 	private final Element targetElement;
 
-	public TapEvent(Object source, Element targetElement, int startX, int startY) {
-	  this.targetElement = targetElement;
-    this.startX = startX;
-    this.startY = startY;
-    setSource(source);
-  }
+	 public TapEvent(Object source, Element targetElement, Touch touch) {
+	    this.targetElement = targetElement;
+	    this.touch = touch;
+	    setSource(source);
+	  }
 
 	@Override
 	public com.google.gwt.event.shared.GwtEvent.Type<TapHandler> getAssociatedType() {
@@ -54,15 +53,23 @@ public class TapEvent extends GwtEvent<TapHandler> {
 		return TYPE;
 	}
 
-	public int getStartX() {
-		return startX;
-	}
-
-	public int getStartY() {
-		return startY;
-	}
-
 	/**
+	 * Get access to other useful position information related to the tap event
+	 * @return
+	 */
+	public Touch getTouch() {
+		return touch;
+	}
+
+  public int getStartX() {
+    return touch.getPageX();
+  }
+
+  public int getStartY() {
+    return touch.getPageY();
+  }
+
+  /**
 	 * Returns the element that was the actual target of the Tap event.
 	 */
 	public Element getTargetElement() {

--- a/src/main/java/com/googlecode/mgwt/dom/client/recognizer/TapRecognizer.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/recognizer/TapRecognizer.java
@@ -44,6 +44,8 @@ public class TapRecognizer implements TouchHandler {
 
 	private boolean hasMoved;
 
+	private Touch touch;
+
 	private int start_x;
 
 	private int start_y;
@@ -78,9 +80,9 @@ public class TapRecognizer implements TouchHandler {
 		}else {
 			targetElement = null;
 		}
-
-		start_x = event.getTouches().get(0).getPageX();
-		start_y = event.getTouches().get(0).getPageY();
+		touch = event.getTouches().get(0);
+		start_x = touch.getPageX();
+		start_y = touch.getPageY();
 	}
 
 	@Override
@@ -94,7 +96,7 @@ public class TapRecognizer implements TouchHandler {
 	@Override
 	public void onTouchEnd(TouchEndEvent event) {
 		if (!hasMoved && !touchCanceled) {
-			TapEvent tapEvent = new TapEvent(source, targetElement, start_x, start_y);
+			TapEvent tapEvent = new TapEvent(source, targetElement, touch);
 			getEventPropagator().fireEvent(source, tapEvent);
 		}
 	}

--- a/src/main/java/com/googlecode/mgwt/image/client/ImageConverter.java
+++ b/src/main/java/com/googlecode/mgwt/image/client/ImageConverter.java
@@ -100,7 +100,7 @@ public class ImageConverter {
     }
   }
 
-  public ImageResource convert(ImageResource resource, String color) {
+  public void convert(final ImageResource resource, String color, final ImageConverterCallback imageConverterCallback) {
 
     if (color == null) {
       throw new IllegalArgumentException();
@@ -110,49 +110,71 @@ public class ImageConverter {
       throw new IllegalArgumentException();
     }
 
-    int hexColor = Integer.parseInt(color.substring(1), 16);
+    final int hexColor = Integer.parseInt(color.substring(1), 16);
 
-    int red = hexColor >> 16 & 0xFF;
-    int green = hexColor >> 8 & 0xFF;
-    int blue = hexColor & 0xFF;
+    final int red = hexColor >> 16 & 0xFF;
+    final int green = hexColor >> 8 & 0xFF;
+    final int blue = hexColor & 0xFF;
 
-    int height = resource.getHeight();
-    int width = resource.getWidth();
+    final int height = resource.getHeight();
+    final int width = resource.getWidth();
 
-    ImageElement imageElement = loadImage(resource.getSafeUri().asString(),
-        width, height);
+    loadImage(resource.getSafeUri().asString(), width, height, new LoadImageCallback() {
+      @Override
+      public void onFailure(Throwable caught)
+      {
+        imageConverterCallback.onFailure(caught);
+      }
 
-    Canvas canvas = Canvas.createIfSupported();
-    canvas.getElement().setPropertyInt("height", height);
-   canvas.getElement().setPropertyInt("width", width);
+      @Override
+      public void onSuccess(ImageElement imageElement)
+      {
+        try
+        {
+          Canvas canvas = Canvas.createIfSupported();
+          canvas.getElement().setPropertyInt("height", height);
+          canvas.getElement().setPropertyInt("width", width);
 
-    Context2d context = canvas.getContext2d();
-    context.drawImage(imageElement, 0, 0);
-    ImageData imageData = context.getImageData(0, 0, width,
-        height);
+          Context2d context = canvas.getContext2d();
+          context.drawImage(imageElement, 0, 0);
+          ImageData imageData = context.getImageData(0, 0, width, height);
 
-    CanvasPixelArray canvasPixelArray = imageData.getData();
+          CanvasPixelArray canvasPixelArray = imageData.getData();
 
-    for (int i = 0; i < canvasPixelArray.getLength(); i += 4) {
-      canvasPixelArray.set(i, red);
-      canvasPixelArray.set(i + 1, green);
-      canvasPixelArray.set(i + 2, blue);
-      canvasPixelArray.set(i + 3,
-      canvasPixelArray.get(i + 3));
-    }
-    context.putImageData(imageData, 0, 0);
+          for (int i = 0; i < canvasPixelArray.getLength(); i += 4) {
+            canvasPixelArray.set(i, red);
+            canvasPixelArray.set(i + 1, green);
+            canvasPixelArray.set(i + 2, blue);
+            canvasPixelArray.set(i + 3,
+            canvasPixelArray.get(i + 3));
+          }
+          context.putImageData(imageData, 0, 0);
+          imageConverterCallback.onSuccess(new ConvertedImageResource(
+                  canvas.toDataUrl("image/png"), resource.getWidth(),
+                  resource.getHeight()));
+        }
+        catch(Throwable e)
+        {
+          this.onFailure(e);
+        }
+      }
+    });
 
-
-    return new ConvertedImageResource(
-        canvas.toDataUrl("image/png"), resource.getWidth(),
-        resource.getHeight());
   }
 
-  protected native ImageElement loadImage(String dataUrl, int width, int height) /*-{
+  protected native void loadImage(String dataUrl, int width, int height, LoadImageCallback callback) /*-{
     var img = new Image();
     img.width = width;
     img.height = height;
     img.src = dataUrl;
-    return img;
+    img.onload = $entry(function(){
+      callback.@com.googlecode.mgwt.image.client.LoadImageCallback::onSuccess(Lcom/google/gwt/dom/client/ImageElement;)(img);
+    });
+    img.onerror = $entry(function(e){
+      callback.@com.googlecode.mgwt.image.client.LoadImageCallback::onFailure(Ljava/lang/Throwable;)(e);
+    });
+    img.onabort = $entry(function(e){
+      callback.@com.googlecode.mgwt.image.client.LoadImageCallback::onFailure(Ljava/lang/Throwable;)(e);
+    });
   }-*/;
 }

--- a/src/main/java/com/googlecode/mgwt/image/client/ImageConverterCallback.java
+++ b/src/main/java/com/googlecode/mgwt/image/client/ImageConverterCallback.java
@@ -1,0 +1,8 @@
+package com.googlecode.mgwt.image.client;
+
+import com.google.gwt.resources.client.ImageResource;
+
+public interface ImageConverterCallback{
+  public void onSuccess(ImageResource imageResource);
+  public void onFailure(Throwable e);  
+}

--- a/src/main/java/com/googlecode/mgwt/image/client/LoadImageCallback.java
+++ b/src/main/java/com/googlecode/mgwt/image/client/LoadImageCallback.java
@@ -1,0 +1,8 @@
+package com.googlecode.mgwt.image.client;
+
+import com.google.gwt.dom.client.ImageElement;
+
+public interface LoadImageCallback{
+  public void onSuccess(ImageElement imageElement);
+  public void onFailure(Throwable e);  
+}

--- a/src/main/java/com/googlecode/mgwt/ui/UI.gwt.xml
+++ b/src/main/java/com/googlecode/mgwt/ui/UI.gwt.xml
@@ -65,14 +65,21 @@ under * the License.
     <when-type-assignable class="com.googlecode.mgwt.ui.client.FormFactor" />
   </generate-with>
 
-  <replace-with class="com.googlecode.mgwt.ui.client.widget.touch.TouchWidgetImpl.TouchWidgetRuntimeImpl">
+  <replace-with class="com.googlecode.mgwt.ui.client.widget.touch.TouchWidgetStandardImpl">
     <when-type-is class="com.googlecode.mgwt.ui.client.widget.touch.TouchWidgetImpl" />
   </replace-with>
 
-  <replace-with class="com.googlecode.mgwt.ui.client.widget.touch.TouchWidgetImpl.TouchWidgetMobileImpl">
+  <replace-with class="com.googlecode.mgwt.ui.client.widget.touch.TouchWidgetTouchImpl">
     <when-type-is class="com.googlecode.mgwt.ui.client.widget.touch.TouchWidgetImpl" />
     <all>
       <when-property-is name="mgwt.user.agent" value="mobile" />
+    </all>
+  </replace-with>
+
+  <replace-with class="com.googlecode.mgwt.ui.client.widget.touch.TouchWidgetPointerImpl">
+    <when-type-is class="com.googlecode.mgwt.ui.client.widget.touch.TouchWidgetImpl" />
+    <all>
+      <when-property-is name="user.agent" value="ie10" />
     </all>
   </replace-with>
 	
@@ -103,6 +110,12 @@ under * the License.
     <when-type-is class="com.googlecode.mgwt.ui.client.util.impl.CssUtilImpl" />
     <any> 
       <when-property-is name="user.agent" value="ie9" />
+    </any>
+  </replace-with>
+
+  <replace-with class="com.googlecode.mgwt.ui.client.util.impl.CssUtilIE10Impl">
+    <when-type-is class="com.googlecode.mgwt.ui.client.util.impl.CssUtilImpl" />
+    <any> 
       <when-property-is name="user.agent" value="ie10" />
     </any>
   </replace-with>

--- a/src/main/java/com/googlecode/mgwt/ui/UI.gwt.xml
+++ b/src/main/java/com/googlecode/mgwt/ui/UI.gwt.xml
@@ -53,10 +53,6 @@ under * the License.
   <define-configuration-property name="mgwt.css.inject" is-multi-valued="false" />
   <set-configuration-property name="mgwt.css.inject" value="end" />
 
-<!--   <generate-with class="com.googlecode.mgwt.ui.generator.OsDetectionGenerator"> -->
-<!--     <when-type-assignable class="com.googlecode.mgwt.ui.client.OsDetection" /> -->
-<!--   </generate-with> -->
-
   <generate-with class="com.googlecode.mgwt.ui.generator.DeviceDensityGenerator">
     <when-type-assignable class="com.googlecode.mgwt.ui.client.DeviceDensity" />
   </generate-with>
@@ -118,6 +114,24 @@ under * the License.
     <any> 
       <when-property-is name="user.agent" value="ie10" />
     </any>
+  </replace-with>
+
+  <replace-with class="com.googlecode.mgwt.ui.client.TouchSupport.TouchSupportStandard">
+    <when-type-is class="com.googlecode.mgwt.ui.client.TouchSupport" />
+  </replace-with>
+
+  <replace-with class="com.googlecode.mgwt.ui.client.TouchSupport.TouchSupportNative">
+    <when-type-is class="com.googlecode.mgwt.ui.client.TouchSupport" />
+    <all>
+      <when-property-is name="mgwt.user.agent" value="mobile"/>
+    </all>
+  </replace-with>
+
+  <replace-with class="com.googlecode.mgwt.ui.client.TouchSupport.TouchSupportEmulatedPointer">
+    <when-type-is class="com.googlecode.mgwt.ui.client.TouchSupport" />
+    <all> 
+      <when-property-is name="user.agent" value="ie10" />
+    </all>
   </replace-with>
 
   <!-- ButtonBar Buttons -->

--- a/src/main/java/com/googlecode/mgwt/ui/UI.gwt.xml
+++ b/src/main/java/com/googlecode/mgwt/ui/UI.gwt.xml
@@ -187,7 +187,19 @@ under * the License.
         <when-property-is name="mgwt.formfactor" value="phone" />
         <when-property-is name="mgwt.formfactor" value="tablet" />
       </any>
+      <none>
+        <when-property-is name="user.agent" value="ie10" />
+      </none>
   </replace-with>
+
+  <!-- but IE10 on wp8/desktop supports resize, IE11 on wp8.1 supports orientation events via the Screen object -->
+  <replace-with class="com.googlecode.mgwt.ui.client.util.impl.IEOrientationHandler">
+    <when-type-is class="com.googlecode.mgwt.ui.client.util.OrientationHandler" />
+      <all>
+        <when-property-is name="user.agent" value="ie10" />
+      </all>
+  </replace-with>
+
 
   <!-- rebind IconHandler implementation -->
   <replace-with class="com.googlecode.mgwt.ui.client.util.IconHandler.IconHandlerEmulatedImpl">

--- a/src/main/java/com/googlecode/mgwt/ui/client/MGWT.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/MGWT.java
@@ -155,7 +155,8 @@ public class MGWT {
     if (TouchSupport.isTouchEventsEmulatedUsingPointerEvents())
     {
       MetaElement ieCompatible = Document.get().createMetaElement();
-      ieCompatible.setHttpEquiv("IE=10");
+      ieCompatible.setHttpEquiv("x-ua-compatible");
+      ieCompatible.setContent("IE=10");
       head.appendChild(ieCompatible);
       
       MetaElement tapHighlight = Document.get().createMetaElement();

--- a/src/main/java/com/googlecode/mgwt/ui/client/MGWT.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/MGWT.java
@@ -33,7 +33,6 @@ import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Anchor;
 import com.google.gwt.user.client.ui.RootPanel;
-
 import com.googlecode.mgwt.dom.client.event.orientation.OrientationChangeEvent;
 import com.googlecode.mgwt.dom.client.event.orientation.OrientationChangeEvent.ORIENTATION;
 import com.googlecode.mgwt.dom.client.event.orientation.OrientationChangeHandler;
@@ -315,13 +314,15 @@ public class MGWT {
   }
 
   private static native void setupPreventScrolling(Element el)/*-{
-		var func = function(event) {
-			event.preventDefault();
-			return false;
-		};
-
-		el.ontouchmove = func;
-
+    var func = function(event) {
+      var tagName = event.target.tagName;
+      if ((tagName == 'INPUT') || (tagName == 'SELECT') || (tagName == 'TEXTAREA'))  {
+        return true;
+      }
+      event.preventDefault();
+      return false;
+    };
+    el.ontouchmove = func;
   }-*/;
 
   private static void setupPreventScrollingIE10(Element el) {

--- a/src/main/java/com/googlecode/mgwt/ui/client/MGWT.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/MGWT.java
@@ -152,7 +152,7 @@ public class MGWT {
 
     scrollingDisabled = settings.isPreventScrolling();
 
-    if (MGWT.getOsDetection().isWindowsPhone())
+    if (TouchSupport.isTouchEventsEmulatedUsingPointerEvents())
     {
       MetaElement ieCompatible = Document.get().createMetaElement();
       ieCompatible.setHttpEquiv("IE=10");

--- a/src/main/java/com/googlecode/mgwt/ui/client/MGWT.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/MGWT.java
@@ -151,6 +151,24 @@ public class MGWT {
     }
 
     scrollingDisabled = settings.isPreventScrolling();
+
+    if (MGWT.getOsDetection().isWindowsPhone())
+    {
+      MetaElement ieCompatible = Document.get().createMetaElement();
+      ieCompatible.setHttpEquiv("IE=10");
+      head.appendChild(ieCompatible);
+      
+      MetaElement tapHighlight = Document.get().createMetaElement();
+      tapHighlight.setName("msapplication-tap-highlight");
+      tapHighlight.setContent("no");
+      head.appendChild(tapHighlight);
+
+      if (settings.isPreventScrolling()) {
+        BodyElement body = Document.get().getBody();
+        setupPreventScrollingIE10(body);
+      }
+    }
+
     if (settings.isPreventScrolling() && getOsDetection().isIOs()) {
       BodyElement body = Document.get().getBody();
       setupPreventScrolling(body);
@@ -304,6 +322,10 @@ public class MGWT {
 		el.ontouchmove = func;
 
   }-*/;
+
+  private static void setupPreventScrollingIE10(Element el) {
+    el.setAttribute("style", "-ms-touch-action: none;");
+  }
 
   /**
    * A utility method to hide the soft keyboard

--- a/src/main/java/com/googlecode/mgwt/ui/client/OsDetection.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/OsDetection.java
@@ -125,6 +125,12 @@ public interface OsDetection {
 	public boolean isPhone();
 
 	/**
+	 * Are we running on Windows Phone 8/8.1
+	 * @return
+	 */
+	public boolean isWindowsPhone();
+	
+	/**
 	 * Are we running on a blackberry device
 	 *
 	 * @return true if running on a blackberry device, otherwise false

--- a/src/main/java/com/googlecode/mgwt/ui/client/OsDetectionRuntimeImpl.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/OsDetectionRuntimeImpl.java
@@ -82,6 +82,16 @@ public class OsDetectionRuntimeImpl implements OsDetection {
   }
 
   @Override
+  public boolean isWindowsPhone()
+  {
+    String userAgent = getUserAgent();
+    if (userAgent.contains("windows phone 8")) {
+      return true;
+    }
+    return false;
+  }
+
+  @Override
   public boolean isBlackBerry() {
     return false;
   }
@@ -140,4 +150,5 @@ public class OsDetectionRuntimeImpl implements OsDetection {
 
     return false;
   }
+
 }

--- a/src/main/java/com/googlecode/mgwt/ui/client/OsDetectionRuntimeImpl.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/OsDetectionRuntimeImpl.java
@@ -78,7 +78,7 @@ public class OsDetectionRuntimeImpl implements OsDetection {
 
   @Override
   public boolean isPhone() {
-    return isIPhone() || isRetina() || isAndroidPhone();
+    return isIPhone() || isRetina() || isAndroidPhone() || isWindowsPhone();
   }
 
   @Override
@@ -119,6 +119,14 @@ public class OsDetectionRuntimeImpl implements OsDetection {
   }-*/;
 
   native double getDevicePixelRatio() /*-{
+    if (!$wnd.devicePixelRatio) {
+      try {
+        if ('deviceXDPI' in $wnd.screen) {
+          $wnd.devicePixelRatio = $wnd.screen.deviceXDPI / $wnd.screen.logicalXDPI;
+        }
+      }
+      catch(e) {}
+    }
     return $wnd.devicePixelRatio || 1;
   }-*/;
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/TouchSupport.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/TouchSupport.java
@@ -1,0 +1,100 @@
+package com.googlecode.mgwt.ui.client;
+
+import com.google.gwt.core.shared.GWT;
+
+public abstract class TouchSupport {
+  
+  private static TouchSupport impl = GWT.create(TouchSupport.class);
+
+  protected abstract boolean _isTouchEventsEmulatedUsingMouseEvents();
+
+  protected abstract boolean _isTouchEventsEmulatedUsingPointerEvents();
+
+  protected abstract boolean _isTouchEventsSupported();
+  
+  public static boolean isTouchEventsEmulatedUsingMouseEvents() {
+    return impl._isTouchEventsEmulatedUsingMouseEvents();
+  }
+
+  public static boolean isTouchEventsEmulatedUsingPointerEvents() {
+    return impl._isTouchEventsEmulatedUsingPointerEvents();
+  }
+
+  public static boolean isTouchEventsSupported() {
+    return impl._isTouchEventsSupported();
+  }
+  
+  public static class TouchSupportStandard extends TouchSupport {
+
+    private static boolean hasTouchSupport;
+    private static TouchSupport delegate;
+    
+    static {
+      hasTouchSupport = hasTouch();
+      if (hasTouchSupport) {
+        delegate = new TouchSupportNative();
+      }
+    }
+
+    private static native boolean hasTouch() /*-{
+      return 'ontouchstart' in $doc.documentElement;
+    }-*/;
+
+
+    @Override
+    protected boolean _isTouchEventsEmulatedUsingMouseEvents() {
+      if (hasTouchSupport) {
+        return delegate._isTouchEventsEmulatedUsingMouseEvents();
+      }
+      return true;
+    }
+
+    @Override
+    protected boolean _isTouchEventsEmulatedUsingPointerEvents() {
+      return false;
+    }
+
+    @Override
+    protected boolean _isTouchEventsSupported() {
+      if (hasTouchSupport) {
+        return delegate._isTouchEventsSupported();
+      }
+      return false;
+    }
+  }
+
+  public static class TouchSupportEmulatedPointer extends TouchSupport {
+    @Override
+    protected boolean _isTouchEventsEmulatedUsingMouseEvents() {
+      return false;
+    }
+
+    @Override
+    protected boolean _isTouchEventsEmulatedUsingPointerEvents() {
+      return true;
+    }
+
+    @Override
+    protected boolean _isTouchEventsSupported() {
+      return false;
+    }
+  }
+
+  public static class TouchSupportNative extends TouchSupport {
+    @Override
+    protected boolean _isTouchEventsEmulatedUsingMouseEvents() {
+      return false;
+    }
+
+    @Override
+    protected boolean _isTouchEventsEmulatedUsingPointerEvents() {
+      return false;
+    }
+
+    @Override
+    protected boolean _isTouchEventsSupported() {
+      return true;
+    }
+  }
+
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/util/IconHandler.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/util/IconHandler.java
@@ -19,8 +19,8 @@ import com.google.gwt.core.shared.GWT;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.resources.client.ImageResource;
-
 import com.googlecode.mgwt.image.client.ImageConverter;
+import com.googlecode.mgwt.image.client.ImageConverterCallback;
 import com.googlecode.mgwt.ui.client.MGWT;
 
 public class IconHandler {
@@ -86,20 +86,30 @@ public class IconHandler {
     private static final ImageConverter converter = new ImageConverter();
 
     @Override
-    public void setIcons(Element element, ImageResource icon, String color) {
+    public void setIcons(final Element element, ImageResource icon, String color) {
       if (icon == null) {
         return;
       }
 
-      element.getStyle().setBackgroundColor("transparent");
-      ImageResource convertImageResource = converter.convert(icon, color);
-      Dimension dimensions = calculateDimensions(convertImageResource);
-      element.getStyle().setWidth(dimensions.width, Unit.PX);
-      element.getStyle().setHeight(dimensions.height, Unit.PX);
-      element.getStyle().setBackgroundImage(
-          "url(" + convertImageResource.getSafeUri().asString() + ")");
-      element.getStyle().setProperty("backgroundSize",
-          dimensions.width + "px " + dimensions.height + "px");
+      converter.convert(icon, color, new ImageConverterCallback() {
+
+        @Override
+        public void onFailure(Throwable caught) {
+        }
+
+        @Override
+        public void onSuccess(ImageResource convertImageResource) {
+          element.getStyle().setBackgroundColor("transparent");
+          Dimension dimensions = calculateDimensions(convertImageResource);
+          element.getStyle().setWidth(dimensions.width, Unit.PX);
+          element.getStyle().setHeight(dimensions.height, Unit.PX);
+          element.getStyle().setBackgroundImage(
+              "url(" + convertImageResource.getSafeUri().asString() + ")");
+          element.getStyle().setProperty("backgroundSize",
+              dimensions.width + "px " + dimensions.height + "px");
+        }
+        
+      });
     }
   }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/util/impl/CssUtilIE10Impl.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/util/impl/CssUtilIE10Impl.java
@@ -3,6 +3,13 @@ package com.googlecode.mgwt.ui.client.util.impl;
 import com.google.gwt.core.client.JsArrayInteger;
 import com.google.gwt.dom.client.Element;
 
+/**
+ * No idea why but there is a slight difference between Windows Phone 8.1 and
+ * Windows Phone 8.1 Update. To force getComputedStyle to return a 3D matrix for
+ * the transform property the translate3d function needs a non-zero z value.
+ * Windows Phone 8.1 works if you specify 0 but Windows Phone 8.1 Update does not, it returns
+ * a 2D matrix. So we force a 3D matrix to be returned by specifying a z value of -1px
+ */
 public class CssUtilIE10Impl implements CssUtilImpl {
 
   public CssUtilIE10Impl() {
@@ -10,7 +17,7 @@ public class CssUtilIE10Impl implements CssUtilImpl {
 
   @Override
   public void translate(Element el, int x, int y) {
-    String cssText = "translate3d(" + x + "px, " + y + "px, 0px)";
+    String cssText = "translate3d(" + x + "px, " + y + "px, -1px)";
     _translate(el, cssText);
   }
 
@@ -104,13 +111,13 @@ public class CssUtilIE10Impl implements CssUtilImpl {
 
   @Override
   public void setTranslateAndZoom(Element el, int x, int y, double scale) {
-    String cssText = "translate3d(" + x + "px, " + y + "px, 0px) scale(" + scale + ")";
+    String cssText = "translate3d(" + x + "px, " + y + "px, -1px) scale(" + scale + ")";
     el.getStyle().setProperty("transform", cssText);
   }
 
   @Override
   public void translatePercent(Element el, double x, double y) {
-    String cssText = "translate3d(" + x + "%, " + y + "%, 0px)";
+    String cssText = "translate3d(" + x + "%, " + y + "%, -1px)";
     _translate(el, cssText);
   }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/util/impl/CssUtilIE10Impl.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/util/impl/CssUtilIE10Impl.java
@@ -1,0 +1,117 @@
+package com.googlecode.mgwt.ui.client.util.impl;
+
+import com.google.gwt.core.client.JsArrayInteger;
+import com.google.gwt.dom.client.Element;
+
+public class CssUtilIE10Impl implements CssUtilImpl {
+
+  public CssUtilIE10Impl() {
+  }
+
+  @Override
+  public void translate(Element el, int x, int y) {
+    String cssText = "translate3d(" + x + "px, " + y + "px, 0px)";
+    _translate(el, cssText);
+  }
+
+  @Override
+  public native void setDelay(Element el, int milliseconds) /*-{
+    el.style.transitionDelay = milliseconds + "ms";
+  }-*/;
+
+  @Override
+  public native void setOpacity(Element el, double opacity) /*-{
+    el.style.opacity = opacity;
+  }-*/;
+
+  @Override
+  public native void setDuration(Element el, int time) /*-{
+    el.style.transitionDuration = time + "ms";
+  }-*/;
+
+  private native void _translate(Element el, String css)/*-{
+    el.style.transform = css;
+  }-*/;
+
+  @Override
+  public void rotate(Element el, int degree) {
+    el.getStyle().setProperty("transform", "rotateZ(" + degree + "deg)");
+  }
+
+  @Override
+  public boolean hasTransform() {
+    return true;
+  }
+
+  @Override
+  public boolean hasTransistionEndEvent() {
+    return true;
+  }
+
+  @Override
+  public boolean has3d() {
+    return true;
+  }
+
+  @Override
+  public String getTransformProperty() {
+    return "transform";
+  }
+
+  @Override
+  public int[] getPositionFromTransForm(Element element) {
+    JsArrayInteger array = getPositionFromTransform(element);
+    return new int[] {array.get(0), array.get(1)};
+  }
+
+  private native JsArrayInteger getPositionFromTransform(Element el)/*-{
+    var matrix = getComputedStyle(el, null)['transform'].replace(
+        /[^0-9-.,]/g, '').split(',');
+    var x = matrix[12] * 1;
+    var y = matrix[13] * 1;
+    return [ x, y ];
+  }-*/;
+
+  @Override
+  public native int getTopPositionFromCssPosition(Element element) /*-{
+		return getComputedStyle(element, null).top.replace(/[^0-9-]/g, '') * 1;
+  }-*/;
+
+  @Override
+  public native int getLeftPositionFromCssPosition(Element element)/*-{
+		return getComputedStyle(element, null).left.replace(/[^0-9-]/g, '') * 1;
+  }-*/;
+
+  @Override
+  public native void resetTransform(Element el) /*-{
+    el.style.transform = "";
+  }-*/;
+
+  @Override
+  public native void setTransistionProperty(Element element, String string) /*-{
+    element.transitionProperty = string;
+  }-*/;
+
+  @Override
+  public native void setTransFormOrigin(Element el, int x, int y) /*-{
+    el.transformOrigin = x + " " + y;
+  }-*/;
+
+  @Override
+  public native void setTransistionTimingFunction(Element element, String string) /*-{
+    el.transitionTimingFunction = string;
+  }-*/;
+
+  @Override
+  public void setTranslateAndZoom(Element el, int x, int y, double scale) {
+    String cssText = "translate3d(" + x + "px, " + y + "px, 0px) scale(" + scale + ")";
+    el.getStyle().setProperty("transform", cssText);
+  }
+
+  @Override
+  public void translatePercent(Element el, double x, double y) {
+    String cssText = "translate3d(" + x + "%, " + y + "%, 0px)";
+    _translate(el, cssText);
+  }
+
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/util/impl/CssUtilIE10Impl.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/util/impl/CssUtilIE10Impl.java
@@ -5,10 +5,9 @@ import com.google.gwt.dom.client.Element;
 
 /**
  * No idea why but there is a slight difference between Windows Phone 8.1 and
- * Windows Phone 8.1 Update. To force getComputedStyle to return a 3D matrix for
- * the transform property the translate3d function needs a non-zero z value.
- * Windows Phone 8.1 works if you specify 0 but Windows Phone 8.1 Update does not, it returns
- * a 2D matrix. So we force a 3D matrix to be returned by specifying a z value of -1px
+ * Windows Phone 8.1 Update. When using translate3d with z=0 getComputedStyle returns
+ * a 3D matrix on Windows Phone 8.1 but for Windows Phone 8.1 Update it returns
+ * a 2D matrix. So we check which matrix is returned before using the relevant elements
  */
 public class CssUtilIE10Impl implements CssUtilImpl {
 
@@ -17,7 +16,7 @@ public class CssUtilIE10Impl implements CssUtilImpl {
 
   @Override
   public void translate(Element el, int x, int y) {
-    String cssText = "translate3d(" + x + "px, " + y + "px, -1px)";
+    String cssText = "translate3d(" + x + "px," + y + "px,0px)";
     _translate(el, cssText);
   }
 
@@ -74,9 +73,16 @@ public class CssUtilIE10Impl implements CssUtilImpl {
   private native JsArrayInteger getPositionFromTransform(Element el)/*-{
     var matrix = getComputedStyle(el, null)['transform'].replace(
         /[^0-9-.,]/g, '').split(',');
-    var x = matrix[12] * 1;
-    var y = matrix[13] * 1;
-    return [ x, y ];
+    if (matrix.length === 6) {
+      var x = matrix[4] * 1;
+      var y = matrix[5] * 1;
+      return [ x, y ];
+    }
+    else {
+      var x = matrix[12] * 1;
+      var y = matrix[13] * 1;
+      return [ x, y ];
+    }
   }-*/;
 
   @Override
@@ -111,13 +117,13 @@ public class CssUtilIE10Impl implements CssUtilImpl {
 
   @Override
   public void setTranslateAndZoom(Element el, int x, int y, double scale) {
-    String cssText = "translate3d(" + x + "px, " + y + "px, -1px) scale(" + scale + ")";
+    String cssText = "translate3d(" + x + "px, " + y + "px,0px) scale(" + scale + ")";
     el.getStyle().setProperty("transform", cssText);
   }
 
   @Override
   public void translatePercent(Element el, double x, double y) {
-    String cssText = "translate3d(" + x + "%, " + y + "%, -1px)";
+    String cssText = "translate3d(" + x + "%, " + y + "%,0%)";
     _translate(el, cssText);
   }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/util/impl/IEOrientationHandler.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/util/impl/IEOrientationHandler.java
@@ -1,0 +1,170 @@
+package com.googlecode.mgwt.ui.client.util.impl;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.event.logical.shared.CloseEvent;
+import com.google.gwt.event.logical.shared.CloseHandler;
+import com.google.gwt.event.logical.shared.ResizeEvent;
+import com.google.gwt.event.logical.shared.ResizeHandler;
+import com.google.gwt.user.client.Window;
+import com.google.web.bindery.event.shared.EventBus;
+import com.googlecode.mgwt.dom.client.event.orientation.OrientationChangeEvent;
+import com.googlecode.mgwt.dom.client.event.orientation.OrientationChangeEvent.ORIENTATION;
+import com.googlecode.mgwt.ui.client.util.OrientationHandler;
+import com.googlecode.mgwt.ui.client.widget.main.MainResourceAppearance.UtilCss;
+import com.googlecode.mgwt.ui.client.widget.main.MainResourceHolder;
+
+/**
+ * IE11 on windows 8 or windows phone 8.1 supports orientation events but via
+ * the Screen object, IE10 on windows phone 8 does not support orientation events.
+ * IE10 on windows phone/desktop does support resize events but they do not appear to
+ * fire on wp8 when the viewport is set to device-width. We fallback to resize events anyhow.
+ */
+public class IEOrientationHandler implements OrientationHandler {
+	private static native JavaScriptObject setupOrientation0(
+  		IEOrientationHandler handler)/*-{
+  	var func = $entry(function(evt) {
+  		handler.@com.googlecode.mgwt.ui.client.util.impl.IEOrientationHandler::onorientationChange(Ljava/lang/String;)(evt.target.msOrientation);
+  	});
+  	$wnd.screen.onmsorientationchange = func;
+  	return func;
+  }-*/;
+
+  private static native void destroyOrientation(JavaScriptObject o)/*-{
+  	$wnd.screen.onmsorientationchange = null;
+  }-*/;
+
+  // update styles on body
+  	private static void setClasses(ORIENTATION o) {
+
+  	  UtilCss utilCss = MainResourceHolder.getUtilCss();
+  		switch (o) {
+
+  		case PORTRAIT:
+  			Document.get().getBody().addClassName(utilCss.portrait());
+  			Document.get().getBody().removeClassName(utilCss.landscape());
+  			break;
+  		case LANDSCAPE:
+  			Document.get().getBody().addClassName(utilCss.landscape());
+  			Document.get().getBody().removeClassName(utilCss.portrait());
+  			break;
+
+  		default:
+  			break;
+  		}
+  	}
+
+  protected static ORIENTATION currentOrientation;
+	protected static boolean orientationInitialized;
+	protected JavaScriptObject nativeJsFunction;
+
+	private EventBus manager;
+
+  @Override
+	public final void maybeSetupOrientation(EventBus manager) {
+		this.manager = manager;
+		if (orientationInitialized)
+			return;
+		if (!GWT.isClient()) {
+			return;
+		}
+		doSetupOrientation();
+		orientationInitialized = true;
+		setClasses(getOrientation());
+	}
+
+	protected void setupNativeBrowerOrientationHandler() {
+	  Window.alert("Settting up native browser orientation handler");
+		nativeJsFunction = setupOrientation0(this);
+		Window.addCloseHandler(new CloseHandler<Window>() {
+
+			@Override
+			public void onClose(CloseEvent<Window> event) {
+				destroyOrientation(nativeJsFunction);
+			}
+		});
+	}
+
+	protected static native String getOrientation0()/*-{
+		if (typeof ($wnd.screen.msOrientation) == 'undefined') {
+			return "portrait-primary";
+		}
+		return $wnd.screen.msOrientation;
+	}-*/;
+
+  protected static ORIENTATION getBrowserOrientation() {
+    String orientation = getOrientation0();
+
+    ORIENTATION o;
+    if ("landscape-primary".equals(orientation) || "landscape-secondary".equals(orientation)) {
+      o = ORIENTATION.LANDSCAPE;
+    }
+    else {
+      o = ORIENTATION.PORTRAIT;
+    }
+    return o;
+  }
+
+  void fireOrientationChangedEvent(ORIENTATION orientation) {
+  	setClasses(orientation);
+  	manager.fireEvent(new OrientationChangeEvent(orientation));
+  }
+
+  private void onorientationChange(String orientation) {
+    ORIENTATION o;
+    if ("landscape-primary".equals(orientation) || "landscape-secondary".equals(orientation)) {
+      o = ORIENTATION.LANDSCAPE;
+    }
+    else {
+      o = ORIENTATION.PORTRAIT;
+    }
+  	currentOrientation = o;
+  	fireOrientationChangedEvent(o);
+  }
+  
+  public void doSetupOrientation() {
+
+    if (!orientationSupported()) {
+      Window.addResizeHandler(new ResizeHandler() {
+
+        @Override
+        public void onResize(ResizeEvent event) {
+          ORIENTATION orientation = getOrientation();
+          if (orientation != currentOrientation) {
+            currentOrientation = orientation;
+            fireOrientationChangedEvent(orientation);
+          }
+        }
+      });
+    } else {
+      setupNativeBrowerOrientationHandler();
+    }
+
+  }
+
+  /**
+   * Get the current orientation of the device
+   *
+   * @return the current orientation of the device
+   */
+  public ORIENTATION getOrientation() {
+    if (!orientationSupported()) {
+      int height = Window.getClientHeight();
+      int width = Window.getClientWidth();
+
+      if (width > height) {
+        return ORIENTATION.LANDSCAPE;
+      } else {
+        return ORIENTATION.PORTRAIT;
+      }
+    } else {
+      return getBrowserOrientation();
+    }
+  }
+
+  private static native boolean orientationSupported() /*-{
+    return "msOrientation" in $wnd.screen;
+  }-*/;
+
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/util/impl/IEOrientationHandler.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/util/impl/IEOrientationHandler.java
@@ -22,8 +22,8 @@ import com.googlecode.mgwt.ui.client.widget.main.MainResourceHolder;
  * fire on wp8 when the viewport is set to device-width. We fallback to resize events anyhow.
  */
 public class IEOrientationHandler implements OrientationHandler {
-	private static native JavaScriptObject setupOrientation0(
-  		IEOrientationHandler handler)/*-{
+  
+	private static native JavaScriptObject setupOrientation0(IEOrientationHandler handler)/*-{
   	var func = $entry(function(evt) {
   		handler.@com.googlecode.mgwt.ui.client.util.impl.IEOrientationHandler::onorientationChange(Ljava/lang/String;)(evt.target.msOrientation);
   	});
@@ -35,6 +35,8 @@ public class IEOrientationHandler implements OrientationHandler {
   	$wnd.screen.onmsorientationchange = null;
   }-*/;
 
+  private boolean orientationSupported = isOrientationSupported();
+  
   // update styles on body
   	private static void setClasses(ORIENTATION o) {
 
@@ -75,7 +77,6 @@ public class IEOrientationHandler implements OrientationHandler {
 	}
 
 	protected void setupNativeBrowerOrientationHandler() {
-	  Window.alert("Settting up native browser orientation handler");
 		nativeJsFunction = setupOrientation0(this);
 		Window.addCloseHandler(new CloseHandler<Window>() {
 
@@ -125,7 +126,7 @@ public class IEOrientationHandler implements OrientationHandler {
   
   public void doSetupOrientation() {
 
-    if (!orientationSupported()) {
+    if (!orientationSupported) {
       Window.addResizeHandler(new ResizeHandler() {
 
         @Override
@@ -149,7 +150,7 @@ public class IEOrientationHandler implements OrientationHandler {
    * @return the current orientation of the device
    */
   public ORIENTATION getOrientation() {
-    if (!orientationSupported()) {
+    if (!orientationSupported) {
       int height = Window.getClientHeight();
       int width = Window.getClientWidth();
 
@@ -163,7 +164,7 @@ public class IEOrientationHandler implements OrientationHandler {
     }
   }
 
-  private static native boolean orientationSupported() /*-{
+  private static native boolean isOrientationSupported() /*-{
     return "msOrientation" in $wnd.screen;
   }-*/;
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/dissolve.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/dissolve.css
@@ -29,3 +29,37 @@
   from { opacity: 0; }
   to { opacity: 1; }
 }
+
+@if user.agent ie10 {
+	.in, .out {
+	  animation-timing-function: ease-in-out;
+	  animation-duration: 300ms;
+	  animation-fill-mode: both;
+	}
+	
+	.in {
+	  animation-name: appear;
+	}
+	
+	.out {
+	  animation-name: dissolve;
+	}
+	
+	.in.reverse {
+	  animation-name: appear;
+	}
+	
+	.out.reverse {
+	  animation-name: dissolve;
+	}
+	
+	@keyframes dissolve {
+	  from { opacity: 1; }
+	  to { opacity: 0; }
+	}
+	
+	@keyframes appear {
+	  from { opacity: 0; }
+	  to { opacity: 1; }
+	}
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/dissolve.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/dissolve.css
@@ -1,3 +1,4 @@
+@if user.agent safari {
 .in, .out {
   -webkit-animation-timing-function: ease-in-out;
   -webkit-animation-duration: 300ms;
@@ -28,6 +29,7 @@
 @-webkit-keyframes appear {
   from { opacity: 0; }
   to { opacity: 1; }
+}
 }
 
 @if user.agent ie10 {

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/fade.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/fade.css
@@ -1,3 +1,4 @@
+@if user.agent safari {
 .in, .out {
   -webkit-animation-timing-function: ease-in-out;
   -webkit-animation-duration: 300ms;
@@ -27,6 +28,7 @@
 @-webkit-keyframes fadeout {
   from { opacity: 1; }
   to { opacity: 0; }
+}
 }
 
 @if user.agent ie10 {

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/fade.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/fade.css
@@ -28,3 +28,36 @@
   from { opacity: 1; }
   to { opacity: 0; }
 }
+
+@if user.agent ie10 {
+	.in, .out {
+	  animation-timing-function: ease-in-out;
+	  animation-duration: 300ms;
+	  animation-fill-mode: both;
+	}
+	
+	.in {
+	  animation-name: fadein;
+	}
+	.out {
+	  animation-name: fadeout;
+	}
+	
+	.in.reverse {
+	  animation-name: fadein;
+	}
+	
+	.out.reverse {
+	  animation-name: fadeout;
+	}
+	
+	@keyframes fadein {
+	  from { opacity: 0; }
+	  to { opacity: 1; }
+	}
+	
+	@keyframes fadeout {
+	  from { opacity: 1; }
+	  to { opacity: 0; }
+	}
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/flip.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/flip.css
@@ -1,3 +1,4 @@
+@if user.agent safari {
 .in, .out {
   -webkit-animation-timing-function: ease-in-out;
   -webkit-animation-duration: 300ms;
@@ -40,6 +41,7 @@
 @-webkit-keyframes flipouttoright {
   from { -webkit-transform: rotateY(0) scale(1); }
   to { -webkit-transform: rotateY(180deg) scale(.8); }
+}
 }
 
 @if user.agent ie10 {

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/flip.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/flip.css
@@ -41,3 +41,49 @@
   from { -webkit-transform: rotateY(0) scale(1); }
   to { -webkit-transform: rotateY(180deg) scale(.8); }
 }
+
+@if user.agent ie10 {
+	.in, .out {
+	  animation-timing-function: ease-in-out;
+	  animation-duration: 300ms;
+	  animation-fill-mode: both;	
+	  animation-duration: .65s;
+	  backface-visibility: hidden;
+	}
+	
+	.in {
+	  animation-name: flipinfromleft;
+	}
+	
+	.out {
+	  animation-name: flipouttoleft;
+	}
+	
+	.in.reverse {
+	  animation-name: flipinfromright;
+	}
+	
+	.out.reverse {
+	  animation-name: flipouttoright;
+	}
+	
+	@keyframes flipinfromright {
+	  from { transform: rotateY(-180deg) scale(.8); }
+	  to { transform: rotateY(0) scale(1); }
+	}
+	
+	@keyframes flipinfromleft {
+	  from { transform: rotateY(180deg) scale(.8); }
+	  to { transform: rotateY(0) scale(1); }
+	}
+	
+	@keyframes flipouttoleft {
+	  from { transform: rotateY(0) scale(1); }
+	  to { transform: rotateY(-180deg) scale(.8); }
+	}
+	
+	@keyframes flipouttoright {
+	  from { transform: rotateY(0) scale(1); }
+	  to { transform: rotateY(180deg) scale(.8); }
+	}
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/pop.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/pop.css
@@ -1,3 +1,4 @@
+@if user.agent safari {
 .in, .out {
   -webkit-animation-timing-function: ease-in-out;
   -webkit-animation-duration: 300ms;
@@ -40,6 +41,7 @@
     -webkit-transform: scale(.3);
     opacity: 0;
   }
+}
 }
 
 @if user.agent ie10 {

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/pop.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/pop.css
@@ -41,3 +41,49 @@
     opacity: 0;
   }
 }
+
+@if user.agent ie10 {
+	.in, .out {
+	  animation-timing-function: ease-in-out;
+	  animation-duration: 300ms;
+	  animation-fill-mode: both;
+	}
+	
+	.in {
+	  animation-name: popin;
+	}
+	
+	.out {
+	  animation-name: popout;
+	}
+	
+	.in.reverse {
+	  animation-name: popin;
+	}
+	
+	.out.reverse {
+	  animation-name: popout;
+	}
+	
+	@keyframes popin {
+	  from {
+	    transform: scale(.3);
+	    opacity: 0;
+	  }
+	  to {
+	    transform: scale(1);
+	    opacity: 1;
+	  }
+	}
+	
+	@keyframes popout {
+	  from {
+	    transform: scale(1);
+	    opacity: 1;
+	  }
+	  to {
+	    transform: scale(.3);
+	    opacity: 0;
+	  }
+	}
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/slide-up.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/slide-up.css
@@ -1,3 +1,4 @@
+@if user.agent safari {
 .in, .out {
   -webkit-animation-timing-function: ease-in-out;
   -webkit-animation-duration: 300ms;
@@ -42,6 +43,7 @@
 @-webkit-keyframes slidedownfromtop {
   from { -webkit-transform: translateY(-100%); }
   to { -webkit-transform: translateY(0%); }
+}
 }
 
 @if user.agent ie10 {

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/slide-up.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/slide-up.css
@@ -43,3 +43,51 @@
   from { -webkit-transform: translateY(-100%); }
   to { -webkit-transform: translateY(0%); }
 }
+
+@if user.agent ie10 {
+	.in, .out {
+	  animation-timing-function: ease-in-out;
+	  animation-duration: 300ms;
+	  animation-fill-mode: both;
+	}
+	
+	.in {
+	  animation-name: slideupfrombottom;
+	  z-index: 10;
+	}
+	
+	.out {
+	  animation-name: slideupfrommiddle;
+	  z-index: 0;
+	}
+	
+	.out.reverse {
+	  z-index: 10;
+	  animation-name: slidedownfrommiddle;
+	}
+	
+	.in.reverse {
+	  z-index: 0;
+	  animation-name: slidedownfromtop;
+	}
+	
+	@keyframes slideupfrombottom {
+	  from { transform: translateY(100%); }
+	  to { transform: translateY(0); }
+	}
+	
+	@keyframes slidedownfrommiddle {
+	  from { transform: translateY(0); }
+	  to { transform: translateY(100%); }
+	}
+	
+	@keyframes slideupfrommiddle {
+	  from { transform: translateY(0); }
+	  to { transform: translateY(-100%); }
+	}
+	
+	@keyframes slidedownfromtop {
+	  from { transform: translateY(-100%); }
+	  to { transform: translateY(0%); }
+	}
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/slide.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/slide.css
@@ -1,3 +1,4 @@
+@if user.agent safari {
 .in, .out {
   -webkit-animation-timing-function: ease-in-out;
   -webkit-animation-duration: 300ms;
@@ -46,6 +47,7 @@
 @-webkit-keyframes slideouttoright {
   from { -webkit-transform: translateX(0); }
   to { -webkit-transform: translateX(100%); }
+}
 }
 
 @if user.agent ie10 {

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/slide.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/slide.css
@@ -47,3 +47,55 @@
   from { -webkit-transform: translateX(0); }
   to { -webkit-transform: translateX(100%); }
 }
+
+@if user.agent ie10 {
+	.in, .out {
+	  animation-timing-function: ease-in-out;
+	  animation-duration: 300ms;
+	  animation-fill-mode: both;
+	}
+	
+	.in {
+	  z-index:10;
+	}
+	
+	.out{
+	  z-index: 0 !important;
+	}
+	
+	.in {
+	  animation-name: slideinfromright;
+	}
+	
+	.out {
+	  animation-name: slideouttoleft;
+	}
+	
+	.in.reverse {
+	  animation-name: slideinfromleft;
+	}
+	
+	.out.reverse {
+	  animation-name: slideouttoright;
+	}
+	
+	@keyframes slideinfromright {
+	  from { transform: translateX(100%); }
+	  to { transform: translateX(0); }
+	}
+	
+	@keyframes slideinfromleft {
+	  from { transform: translateX(-100%); }
+	  to { transform: translateX(0); }
+	}
+	
+	@keyframes slideouttoleft {
+	  from { transform: translateX(0); }
+	  to { transform: translateX(-100%); }
+	}
+	
+	@keyframes slideouttoright {
+	  from { transform: translateX(0); }
+	  to { transform: translateX(100%); }
+	}
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/swap.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/swap.css
@@ -1,3 +1,4 @@
+@if user.agent safari {
 .in, .out {
   -webkit-animation-timing-function: ease-in-out;
   -webkit-animation-fill-mode: both;
@@ -78,6 +79,7 @@
   100% {
     -webkit-transform: translate3d(0px, 0px, 0px) rotateY(0deg);
   }
+}
 }
 
 @if user.agent ie10 {

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/swap.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/bundle/swap.css
@@ -79,3 +79,86 @@
     -webkit-transform: translate3d(0px, 0px, 0px) rotateY(0deg);
   }
 }
+
+@if user.agent ie10 {
+	.in, .out {
+	  animation-timing-function: ease-in-out;
+	  animation-fill-mode: both;
+	  transform: perspective(800);
+	  animation-duration: .7s;
+	}
+	
+	.out {
+	  animation-name: swapouttoleft;
+	}
+	.in {
+	  animation-name: swapinfromright;
+	}
+	.out.reverse {
+	  animation-name: swapouttoright;
+	}
+	.in.reverse {
+	  animation-name: swapinfromleft;
+	}
+	
+	
+	@keyframes swapouttoright {
+	  0% {
+	    transform: translate3d(0px, 0px, 0px) rotateY(0deg);
+	    animation-timing-function: ease-in-out;
+	  }
+	  50% {
+	    transform: translate3d(-180px, 0px, -400px) rotateY(20deg);
+	    animation-timing-function: ease-in;
+	    opacity: 0.8;
+	  }
+	  100% {
+	      transform:  translate3d(0px, 0px, -800px) rotateY(70deg);
+	      opacity: 0;
+	  }
+	}
+	
+	@keyframes swapouttoleft {
+	  0% {
+	    transform: translate3d(0px, 0px, 0px) rotateY(0deg);
+	    animation-timing-function: ease-in-out;
+	  }
+	  50% {
+	    transform:  translate3d(180px, 0px, -400px) rotateY(-20deg);
+	    animation-timing-function: ease-in;
+	    opacity: 0.8;
+	  }
+	  100% {
+	    transform: translate3d(0px, 0px, -800px) rotateY(-70deg);
+	    opacity: 0;
+	  }
+	}
+	
+	@keyframes swapinfromright {
+	  0% {
+	    transform: translate3d(0px, 0px, -800px) rotateY(70deg);
+	    animation-timing-function: ease-out;
+	  }
+	  50% {
+	    transform: translate3d(-180px, 0px, -400px) rotateY(20deg);
+	    animation-timing-function: ease-in-out;
+	  }
+	  100% {
+	    transform: translate3d(0px, 0px, 0px) rotateY(0deg);
+	  }
+	}
+	
+	@keyframes swapinfromleft {
+	  0% {
+	    transform: translate3d(0px, 0px, -800px) rotateY(-70deg);
+	    animation-timing-function: ease-out;
+	  }
+	  50% {
+	    transform: translate3d(180px, 0px, -400px) rotateY(-20deg);
+	    animation-timing-function: ease-in-out;
+	  }
+	  100% {
+	    transform: translate3d(0px, 0px, 0px) rotateY(0deg);
+	  }
+	}
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/impl/AnimationWidgetKeyFrameImpl.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/impl/AnimationWidgetKeyFrameImpl.java
@@ -186,7 +186,7 @@ public class AnimationWidgetKeyFrameImpl implements AnimationWidgetImpl {
 
   private native void blurBeforeAnimation() /*-{
   	var node = $doc.querySelector(":focus");
-  	if (node != null) {
+  	if ((node != null) && !((node.nodeType === 1) && (node.nodeName === "BODY"))) {
   		if (typeof (node.blur) == "function") {
   			node.blur();
   		}

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/impl/animation-display.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/impl/animation-display.css
@@ -3,7 +3,6 @@
   width: 100%;
   height: 100%;
   overflow:hidden;
-  -webkit-backface-visibility: hidden;
 }
 
 .display {
@@ -13,28 +12,27 @@
   right: 0px;
   bottom: 0px;
   overflow:hidden;
-  -webkit-transform-style: preserve-3d;
-  -webkit-backface-visibility: hidden;
-  -webkit-transform: translate3d(0,0,0) rotate(0) scale(1);
-  -webkit-perspective: 800;
 }
 
+
+@if user.agent safari {
+	.displayContainer {
+  		-webkit-backface-visibility: hidden;
+	}
+	
+	.display {
+	  -webkit-transform-style: preserve-3d;
+	  -webkit-backface-visibility: hidden;
+	  -webkit-transform: translate3d(0,0,0) rotate(0) scale(1);
+	  -webkit-perspective: 800;
+	}
+}
 @if user.agent ie10 {
 	.displayContainer {
-	  position: absolute;
-	  width: 100%;
-	  height: 100%;
-	  overflow:hidden;
 	  backface-visibility: hidden;
 	}
 	
 	.display {
-	  position: absolute;
-	  top: 0px;
-	  left: 0px;
-	  right: 0px;
-	  bottom: 0px;
-	  overflow:hidden;
 	  backface-visibility: hidden;
 	  transform: translate3d(0,0,0) rotate(0) scale(1);
 	  perspective: 800;

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/impl/animation-display.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/animation/impl/animation-display.css
@@ -18,3 +18,25 @@
   -webkit-transform: translate3d(0,0,0) rotate(0) scale(1);
   -webkit-perspective: 800;
 }
+
+@if user.agent ie10 {
+	.displayContainer {
+	  position: absolute;
+	  width: 100%;
+	  height: 100%;
+	  overflow:hidden;
+	  backface-visibility: hidden;
+	}
+	
+	.display {
+	  position: absolute;
+	  top: 0px;
+	  left: 0px;
+	  right: 0px;
+	  bottom: 0px;
+	  overflow:hidden;
+	  backface-visibility: hidden;
+	  transform: translate3d(0,0,0) rotate(0) scale(1);
+	  perspective: 800;
+	}
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/button/ButtonBase.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/button/ButtonBase.java
@@ -18,8 +18,8 @@ import com.google.gwt.event.dom.client.TouchEndEvent;
 import com.google.gwt.event.dom.client.TouchMoveEvent;
 import com.google.gwt.event.dom.client.TouchStartEvent;
 import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.ui.HasText;
-
 import com.googlecode.mgwt.dom.client.event.tap.TapEvent;
 import com.googlecode.mgwt.dom.client.event.tap.TapHandler;
 import com.googlecode.mgwt.dom.client.event.touch.TouchHandler;
@@ -32,7 +32,11 @@ import com.googlecode.mgwt.ui.client.widget.touch.TouchWidget;
 public abstract class ButtonBase extends TouchWidget implements HasText {
 
   private boolean active;
-
+  // a temp fix where we no longer add the default touch handlers to the button
+  // until a call is made to set the element for the widget. This is required since
+  // it is not possible to add a bitless dom handler until the element has been set
+  private boolean defaultHandlersAdded;
+  
   private final ButtonBaseAppearance baseAppearance;
 
   /**
@@ -43,56 +47,6 @@ public abstract class ButtonBase extends TouchWidget implements HasText {
    */
   public ButtonBase(ButtonBaseAppearance appearance) {
     this.baseAppearance = appearance;
-
-    addTouchHandler(new TouchHandler() {
-
-      @Override
-      public void onTouchCancel(TouchCancelEvent event) {
-        event.stopPropagation();
-        event.preventDefault();
-        removeStyleName(ButtonBase.this.baseAppearance.css().active());
-        if (MGWT.getFormFactor().isDesktop()) {
-          DOM.releaseCapture(getElement());
-        }
-        active = false;
-      }
-
-      @Override
-      public void onTouchEnd(TouchEndEvent event) {
-        event.stopPropagation();
-        event.preventDefault();
-        removeStyleName(ButtonBase.this.baseAppearance.css().active());
-        if (MGWT.getFormFactor().isDesktop()) {
-          DOM.releaseCapture(getElement());
-        }
-        active = false;
-      }
-
-      @Override
-      public void onTouchMove(TouchMoveEvent event) {
-        event.preventDefault();
-        event.stopPropagation();
-      }
-
-      @Override
-      public void onTouchStart(TouchStartEvent event) {
-        event.stopPropagation();
-        event.preventDefault();
-        addStyleName(ButtonBase.this.baseAppearance.css().active());
-        if (MGWT.getFormFactor().isDesktop()) {
-          DOM.setCapture(getElement());
-        }
-        active = true;
-      }
-    });
-
-    addTapHandler(new TapHandler() {
-
-      @Override
-      public void onTap(TapEvent event) {
-        removeStyleName(ButtonBase.this.baseAppearance.css().active());
-      }
-    });
   }
 
   @Override
@@ -108,4 +62,66 @@ public abstract class ButtonBase extends TouchWidget implements HasText {
   public boolean isActive() {
     return active;
   }
+
+  @Override
+  protected void setElement(Element elem)
+  {
+    super.setElement(elem);
+    
+    if (!defaultHandlersAdded)
+    {
+      addTouchHandler(new TouchHandler() {
+
+        @Override
+        public void onTouchCancel(TouchCancelEvent event) {
+          event.stopPropagation();
+          event.preventDefault();
+          removeStyleName(ButtonBase.this.baseAppearance.css().active());
+          if (MGWT.getFormFactor().isDesktop() || MGWT.getOsDetection().isWindowsPhone()) {
+            DOM.releaseCapture(getElement());
+          }
+          active = false;
+        }
+
+        @Override
+        public void onTouchEnd(TouchEndEvent event) {
+          event.stopPropagation();
+          event.preventDefault();
+          removeStyleName(ButtonBase.this.baseAppearance.css().active());
+          if (MGWT.getFormFactor().isDesktop() || MGWT.getOsDetection().isWindowsPhone()) {
+            DOM.releaseCapture(getElement());
+          }
+          active = false;
+        }
+
+        @Override
+        public void onTouchMove(TouchMoveEvent event) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+
+        @Override
+        public void onTouchStart(TouchStartEvent event) {
+          event.stopPropagation();
+          event.preventDefault();
+          addStyleName(ButtonBase.this.baseAppearance.css().active());
+          if (MGWT.getFormFactor().isDesktop() || MGWT.getOsDetection().isWindowsPhone()) {
+            DOM.setCapture(getElement());
+          }
+          active = true;
+        }
+      });
+      
+      addTapHandler(new TapHandler() {
+
+        @Override
+        public void onTap(TapEvent event) {
+          removeStyleName(ButtonBase.this.baseAppearance.css().active());
+        }
+      });
+      defaultHandlersAdded = true;
+    }
+  }
+  
+  
 }

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/button/ButtonBase.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/button/ButtonBase.java
@@ -23,7 +23,7 @@ import com.google.gwt.user.client.ui.HasText;
 import com.googlecode.mgwt.dom.client.event.tap.TapEvent;
 import com.googlecode.mgwt.dom.client.event.tap.TapHandler;
 import com.googlecode.mgwt.dom.client.event.touch.TouchHandler;
-import com.googlecode.mgwt.ui.client.MGWT;
+import com.googlecode.mgwt.ui.client.TouchSupport;
 import com.googlecode.mgwt.ui.client.widget.touch.TouchWidget;
 
 /**
@@ -77,7 +77,7 @@ public abstract class ButtonBase extends TouchWidget implements HasText {
           event.stopPropagation();
           event.preventDefault();
           removeStyleName(ButtonBase.this.baseAppearance.css().active());
-          if (MGWT.getFormFactor().isDesktop() || MGWT.getOsDetection().isWindowsPhone()) {
+          if (TouchSupport.isTouchEventsEmulatedUsingMouseEvents()) {
             DOM.releaseCapture(getElement());
           }
           active = false;
@@ -88,7 +88,7 @@ public abstract class ButtonBase extends TouchWidget implements HasText {
           event.stopPropagation();
           event.preventDefault();
           removeStyleName(ButtonBase.this.baseAppearance.css().active());
-          if (MGWT.getFormFactor().isDesktop() || MGWT.getOsDetection().isWindowsPhone()) {
+          if (TouchSupport.isTouchEventsEmulatedUsingMouseEvents()) {
             DOM.releaseCapture(getElement());
           }
           active = false;
@@ -105,7 +105,7 @@ public abstract class ButtonBase extends TouchWidget implements HasText {
           event.stopPropagation();
           event.preventDefault();
           addStyleName(ButtonBase.this.baseAppearance.css().active());
-          if (MGWT.getFormFactor().isDesktop() || MGWT.getOsDetection().isWindowsPhone()) {
+          if (TouchSupport.isTouchEventsEmulatedUsingMouseEvents()) {
             DOM.setCapture(getElement());
           }
           active = true;

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/button/ButtonBase.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/button/ButtonBase.java
@@ -123,5 +123,8 @@ public abstract class ButtonBase extends TouchWidget implements HasText {
     }
   }
   
+  public ButtonBaseAppearance getAppearance() {
+    return baseAppearance;
+  }
   
 }

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/button/imagebutton.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/button/imagebutton.css
@@ -14,9 +14,9 @@
   }
 }
 
-@if user.agent gecko1_8 {
+@if user.agent ie10 {
   .mgwt-ImageButton {
-    display: -moz-box;
+    display: -ms-flexbox;
   }
 }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/buttonbar/buttonbar.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/buttonbar/buttonbar.css
@@ -26,9 +26,16 @@
   }
 }
 
-@if user.agent ie9 ie10 {
+@if user.agent ie9 {
   .mgwt-ButtonBar {
     display: table;
+  }
+}
+
+@if user.agent ie10 {
+  .mgwt-ButtonBar {
+    display: -ms-flexbox;
+    -ms-flex-direction: horizontal;
   }
 }
 
@@ -46,7 +53,7 @@
   font-weight: bold;
 }
 
-@if user.agent ie9 ie10 {
+@if user.agent ie9 {
   .mgwt-ButtonBar-text {
     display: table-cell;
     vertical-align: middle;

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/carousel/carousel.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/carousel/carousel.css
@@ -18,7 +18,7 @@
 @if user.agent ie10 {
   .mgwt-Carousel {
     display: -ms-flexbox;
-    -ms-flex: 1;
+    -ms-flex: 1 1;
   }
 }
 
@@ -38,7 +38,7 @@
 
 @if user.agent ie10 {
   .mgwt-Carousel-Scroller, .mgwt-Carousel-Container  {
-    -ms-flex: 1;
+    -ms-flex: 1 1;
   }
 }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/carousel/carousel.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/carousel/carousel.css
@@ -15,6 +15,13 @@
   }
 }
 
+@if user.agent ie10 {
+  .mgwt-Carousel {
+    display: -ms-flexbox;
+    -ms-flex: 1;
+  }
+}
+
 .mgwt-Carousel {
   position: relative;
   flex:1;
@@ -26,6 +33,12 @@
   .mgwt-Carousel-Scroller, .mgwt-Carousel-Container  {
     -webkit-box-flex: 1; /* iOS < 7 && Android < 4.4*/
     -webkit-flex: 1;
+  }
+}
+
+@if user.agent ie10 {
+  .mgwt-Carousel-Scroller, .mgwt-Carousel-Container  {
+    -ms-flex: 1;
   }
 }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/dialog/options/options-dialog.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/dialog/options/options-dialog.css
@@ -12,3 +12,9 @@
   border-top: 1px solid #030506;
   padding: 10px;
 }
+
+@if user.agent ie10 {
+  .mgwt-OptionsDialog {
+	  background-image: linear-gradient(to bottom, rgba(50, 74, 103, 0.9) 0%, rgba(20, 25, 35, 0.9) 2%, rgba(0, 0, 0, 0.0) 100%);
+  }
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/dialog/panel/dialog-button.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/dialog/panel/dialog-button.css
@@ -26,7 +26,7 @@
 
 @if user.agent ie10 {
   .mgwt-DialogButton  {
-    -ms-flex: 1;
+    -ms-flex: 1 1;
   }
 }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/dialog/panel/dialog-button.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/dialog/panel/dialog-button.css
@@ -3,6 +3,7 @@
   @external mgwt-DialogButton-cancel, mgwt-DialogButton-active;
 }
 .mgwt-DialogButton {
+  -webkit-box-flex: 1;
   -webkit-flex: 1;
   flex: 1;
   padding: 9px 13px;
@@ -20,6 +21,12 @@
 @if mgwt.formfactor desktop {
   .mgwt-DialogButton  {
     cursor: pointer;
+  }
+}
+
+@if user.agent ie10 {
+  .mgwt-DialogButton  {
+    -ms-flex: 1;
   }
 }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/dialog/panel/dialog.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/dialog/panel/dialog.css
@@ -33,15 +33,32 @@
   text-align: center;
 }
 
+@if user.agent ie10 {
+	.mgwt-DialogPanel-footer {
+		display: -ms-flexbox;
+		-ms-flex-pack: center;
+	}
+}
+
+@if user.agent safari {
+	.mgwt-DialogPanel-footer {
+		display: -webkit-box; /* iOS < 7 && Android < 4.4*/
+	    display: -webkit-flex;
+	    -webkit-box-pack: center; /* iOS < 7 && Android < 4.4*/
+	    -webkit-justify-content: center;
+	}
+}
+
+@if user.agent gecko1_8 {
+	.mgwt-DialogPanel-footer {
+ 	 	display: -moz-box;
+        -moz-justify-content: center;
+	}
+}
+
 .mgwt-DialogPanel-footer {
   margin-top: 10px;
-  display: -webkit-box; /* iOS < 7 && Android < 4.4*/
-  display: -moz-box;
-  display: -ms-flexbox;
-  display: -webkit-flex;
   display: flex;
-  -webkit-box-pack: center; /* iOS < 7 && Android < 4.4*/
-  -webkit-justify-content: center;
-  -moz-justify-content: center;
   justify-content: center;
 }
+

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/form/form.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/form/form.css
@@ -30,7 +30,7 @@
 @if user.agent ie10 {
   .mgwt-Form-Entry {
     display: -ms-flexbox;
-    -ms-box-pack: center;
+    -ms-flex-pack: center;
   }
 }
 
@@ -96,7 +96,7 @@
 
 @if user.agent ie10 {
   .mgwt-Form-Entry-container {
-    -ms-flex: 1;
+    -ms-flex: 1 1;
     -ms-flex-pack: end;
     display: -ms-flexbox;
   }

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/form/form.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/form/form.css
@@ -27,12 +27,18 @@
   }
 }
 
+@if user.agent ie10 {
+  .mgwt-Form-Entry {
+    display: -ms-flexbox;
+    -ms-box-pack: center;
+  }
+}
+
 @if user.agent gecko1_8 {
   .mgwt-Form-Entry {
     width: 100%;
     -moz-justify-content: center;
     display: -moz-box;
-    display: -ms-flexbox; /* IE is in FF permutation */
   }
 }
 
@@ -57,6 +63,13 @@
   }
 }
 
+@if user.agent ie10 {
+  .mgwt-Form-Entry-label {
+    width: 30%;
+    display: -ms-flexbox;
+  }
+}
+
 @if user.agent gecko1_8 {
   .mgwt-Form-Entry-label {
     width: 30%;
@@ -78,6 +91,14 @@
     -webkit-box-flex: 1;
     -webkit-box-pack: end;
     display: -webkit-box;
+  }
+}
+
+@if user.agent ie10 {
+  .mgwt-Form-Entry-container {
+    -ms-flex: 1;
+    -ms-flex-pack: end;
+    display: -ms-flexbox;
   }
 }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/input/checkbox/MCheckBox.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/input/checkbox/MCheckBox.java
@@ -31,9 +31,8 @@ import com.google.gwt.uibinder.client.UiFactory;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.HasValue;
-
 import com.googlecode.mgwt.dom.client.event.touch.TouchHandler;
-import com.googlecode.mgwt.ui.client.MGWT;
+import com.googlecode.mgwt.ui.client.TouchSupport;
 import com.googlecode.mgwt.ui.client.util.CssUtil;
 import com.googlecode.mgwt.ui.client.widget.touch.TouchWidget;
 
@@ -59,7 +58,7 @@ public class MCheckBox extends TouchWidget implements HasValue<Boolean>, IsEdito
 			}
 			event.stopPropagation();
 			event.preventDefault();
-			if (MGWT.getFormFactor().isDesktop()) {
+      if (TouchSupport.isTouchEventsEmulatedUsingMouseEvents()) {
 				DOM.releaseCapture(getElement());
 			}
 			setValue(getValue());
@@ -73,7 +72,7 @@ public class MCheckBox extends TouchWidget implements HasValue<Boolean>, IsEdito
 
 			event.stopPropagation();
 			event.preventDefault();
-			if (MGWT.getFormFactor().isDesktop()) {
+      if (TouchSupport.isTouchEventsEmulatedUsingMouseEvents()) {
 				DOM.releaseCapture(getElement());
 			}
 
@@ -120,7 +119,7 @@ public class MCheckBox extends TouchWidget implements HasValue<Boolean>, IsEdito
 			}
 			event.stopPropagation();
 			event.preventDefault();
-			if (MGWT.getFormFactor().isDesktop()) {
+      if (TouchSupport.isTouchEventsEmulatedUsingMouseEvents()) {
 				DOM.setCapture(getElement());
 			}
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/input/checkbox/checkbox.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/input/checkbox/checkbox.css
@@ -41,6 +41,12 @@
   }
 }
 
+@if user.agent ie10 {
+  .mgwt-CheckBox-middle {
+    transition: all 0.1s ease-in-out;
+  }
+}
+
 @if user.agent gecko1_8 {
   .mgwt-CheckBox-middle {
     -moz-transition: all 0.1s ease-in-out;
@@ -60,6 +66,12 @@
 @if user.agent safari {
   .mgwt-CheckBox-middle-content {
     -webkit-box-sizing: border-box;
+  }
+}
+
+@if user.agent ie10 {
+  .mgwt-CheckBox-middle-content {
+    box-sizing: border-box;
   }
 }
 
@@ -85,6 +97,12 @@
   }
 }
 
+@if user.agent ie10 {
+  .mgwt-CheckBox-on {
+    transition: all 0.1s ease-in-out;
+  }
+}
+
 @if user.agent gecko1_8 {
   .mgwt-CheckBox-on {
     -moz-transition: all 0.1s ease-in-out;
@@ -105,6 +123,12 @@
 @if user.agent safari {
   .mgwt-CheckBox-off {
     -webkit-transition: all 0.1s ease-in-out;
+  }
+}
+
+@if user.agent ie10 {
+  .mgwt-CheckBox-off {
+    transition: all 0.1s ease-in-out;
   }
 }
 
@@ -138,6 +162,30 @@
   }
 }
 
+@if user.agent ie10 {
+  .mgwt-CheckBox-important .mgwt-CheckBox-on {
+    background-color: #fe9c12;
+  }
+  .mgwt-CheckBox-notchecked .mgwt-CheckBox-middle {
+    transform: translate3d(-41px,0,0);
+  }
+  .mgwt-CheckBox-checked .mgwt-CheckBox-middle {
+    transform: translate3d(0px,0,0);
+  }
+  .mgwt-CheckBox-notchecked .mgwt-CheckBox-off {
+    transform: translate3d(-41px,0,0);
+  }
+  .mgwt-CheckBox-checked .mgwt-CheckBox-off {
+    transform: translate3d(10px,0,0);
+  }
+  .mgwt-CheckBox-notchecked .mgwt-CheckBox-on {
+    transform: translate3d(-81px,0,0);
+  }
+  .mgwt-CheckBox-checked .mgwt-CheckBox-on {
+    transform: translate3d(0px,0,0);
+  }
+}
+
 @if user.agent gecko1_8 {
   .mgwt-CheckBox-important .mgwt-CheckBox-on {
     border: solid 1px #d87101;
@@ -164,7 +212,7 @@
 }
 
 /*TODO add browser....*/
-@if user.agent ie8 ie9 ie10 {
+@if user.agent ie8 ie9 {
   .mgwt-CheckBox-important .mgwt-CheckBox-on {}
   .mgwt-CheckBox-notchecked .mgwt-CheckBox-middle {}
   .mgwt-CheckBox-checked .mgwt-CheckBox-middle {}

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/input/input.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/input/input.css
@@ -24,6 +24,10 @@
     -ms-flex: 1 1;
     -ms-user-select: text;
   }
+
+  textarea.mgwt-InputBox-box {
+    -ms-touch-action: pan-y;
+  }
 }
 
 @if user.agent gecko1_8 {

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/input/input.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/input/input.css
@@ -21,7 +21,7 @@
   .mgwt-TextBox, .mgwt-InputBox-box, .mgwt-PasswordTextBox,
   .mgwt-InputBox-box, .mgwt-TextArea, .mgwt-InputBox-box {
     display: -ms-flexbox;
-    -ms-flex: 1;
+    -ms-flex: 1 1;
     -ms-user-select: text;
   }
 }

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/input/input.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/input/input.css
@@ -17,6 +17,15 @@
   }
 }
 
+@if user.agent ie10 {
+  .mgwt-TextBox, .mgwt-InputBox-box, .mgwt-PasswordTextBox,
+  .mgwt-InputBox-box, .mgwt-TextArea, .mgwt-InputBox-box {
+    display: -ms-flexbox;
+    -ms-flex: 1;
+    -ms-user-select: text;
+  }
+}
+
 @if user.agent gecko1_8 {
   .mgwt-TextBox, .mgwt-InputBox-box, .mgwt-PasswordTextBox,
   .mgwt-InputBox-box, .mgwt-TextArea, .mgwt-InputBox-box {

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/input/listbox/mlistbox.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/input/listbox/mlistbox.css
@@ -16,6 +16,13 @@
   }
 }
 
+@if user.agent ie10 {
+  .mgwt-ListBox {
+    display: -ms-flexbox;
+    -ms-user-select: text;
+  }
+}
+
 @if user.agent gecko1_8 {
   .mgwt-ListBox {
     display: -moz-box;

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/input/listbox/mlistbox.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/input/listbox/mlistbox.css
@@ -21,6 +21,10 @@
     display: -ms-flexbox;
     -ms-user-select: text;
   }
+
+  select::-ms-expand {
+    display: none;
+  }
 }
 
 @if user.agent gecko1_8 {

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/input/radio/mradiobutton.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/input/radio/mradiobutton.css
@@ -29,6 +29,18 @@
   }
 }
 
+@if user.agent ie10 {
+  .mgwt-RadioButton {
+    display: -ms-flexbox;
+    -ms-flex-direction: row;
+    -ms-flex: 1;
+  }
+  .mgwt-RadioButton-label {
+    display: -ms-flexbox;
+    -ms-flex: 1;
+  }
+}
+
 @if user.agent gecko1_8 {
   .mgwt-RadioButton {
     display: -moz-box;
@@ -80,6 +92,13 @@
   }
   .mgwt-RadioButton-input:CHECKED {
     -webkit-appearance: none;
+  }
+}
+
+@if user.agent ie10 {
+  .mgwt-RadioButton-input {
+  }
+  .mgwt-RadioButton-input:CHECKED {
   }
 }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/input/radio/mradiobutton.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/input/radio/mradiobutton.css
@@ -33,11 +33,11 @@
   .mgwt-RadioButton {
     display: -ms-flexbox;
     -ms-flex-direction: row;
-    -ms-flex: 1;
+    -ms-flex: 1 1;
   }
   .mgwt-RadioButton-label {
     display: -ms-flexbox;
-    -ms-flex: 1;
+    -ms-flex: 1 1;
   }
 }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/input/search/searchbox.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/input/search/searchbox.css
@@ -7,7 +7,9 @@
   @external mgwt-SearchBox-icon;
 }
 
-::-webkit-search-cancel-button { -webkit-appearance: none; }
+@if user.agent safari {
+	::-webkit-search-cancel-button { -webkit-appearance: none; }
+}
 
 .mgwt-SearchBox {
   height: 44px;
@@ -38,6 +40,12 @@
   }
 }
 
+@if user.agent ie10 {
+  .mgwt-SearchBox-input {
+    width: literal("calc(100% - 47px)");
+  }
+}
+
 @if user.agent gecko1_8 {
   .mgwt-SearchBox-input {
     width: literal("-moz-calc(100% - 47px);");
@@ -52,6 +60,12 @@
   }
 }
 
+@if user.agent ie10 {
+  .mgwt-SearchBox-input {
+    -ms-user-select: text;
+  }
+}
+
 @if user.agent gecko1_8 {
   .mgwt-SearchBox-input {
     top: 5px;
@@ -61,7 +75,7 @@
   }
 }
 
-@if user.agent ie9 ie10 {
+@if user.agent ie9 {
   .mgwt-SearchBox-input {
     top: 5px;
   }
@@ -93,6 +107,13 @@
   }
 }
 
+@if user.agent ie10 {
+  .mgwt-SearchBox-icon {
+    background-image: searchImage;
+    background-repeat: no-repeat;
+  }
+}
+
 .mgwt-SearchBox-icon {
     position: relative;
     top: 7px;
@@ -102,25 +123,48 @@
     background-color: #78787E;
   }
 
-@if mgwt.density high {
-  .mgwt-SearchBox-icon {
-    -webkit-mask-size: 17px 17px;
-  }
-}
-
-@if mgwt.density xhigh {
-  .mgwt-SearchBox-icon {
-    -webkit-mask-size: 12px 12px;
-  }
-}
-
 @if user.agent safari {
+
+	@if mgwt.density high {
+	  .mgwt-SearchBox-icon {
+	    -webkit-mask-size: 17px 17px;
+	  }
+	}
+	
+	@if mgwt.density xhigh {
+	  .mgwt-SearchBox-icon {
+	    -webkit-mask-size: 12px 12px;
+	  }
+	}
+	
   .mgwt-SearchBox-clear {
     -webkit-mask-image: clearImage;
     -webkit-mask-position: center center;
     -webkit-mask-repeat: no-repeat;
   }	
 }
+
+@if user.agent ie10 {
+
+	@if mgwt.density high {
+	  .mgwt-SearchBox-icon {
+	    background-size: 17px 17px;
+	  }
+	}
+	
+	@if mgwt.density xhigh {
+	  .mgwt-SearchBox-icon {
+	    background-size: 12px 12px;
+	  }
+	}
+	
+  .mgwt-SearchBox-clear {
+    background-image: clearImage;
+    background-position: center center;
+    background-repeat: no-repeat;
+  }	
+}
+
 
 .mgwt-SearchBox-clear {
   position: absolute;
@@ -131,14 +175,32 @@
   background-color: #78787E;
 }
 
-@if mgwt.density high {
-  .mgwt-SearchBox-clear {
-    -webkit-mask-size: 19px 19px;
-  }
+@if user.agent safari {
+
+	@if mgwt.density high {
+	  .mgwt-SearchBox-clear {
+	    -webkit-mask-size: 19px 19px;
+	  }
+	}
+	
+	@if mgwt.density xhigh {
+	  .mgwt-SearchBox-clear {
+	    -webkit-mask-size: 14px 14px;
+	  }
+	}
 }
 
-@if mgwt.density xhigh {
-  .mgwt-SearchBox-clear {
-    -webkit-mask-size: 14px 14px;
-  }
+@if user.agent ie10 {
+
+	@if mgwt.density high {
+	  .mgwt-SearchBox-clear {
+	    background-size: 19px 19px;
+	  }
+	}
+	
+	@if mgwt.density xhigh {
+	  .mgwt-SearchBox-clear {
+	    background-size: 14px 14px;
+	  }
+	}
 }

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/input/slider/Slider.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/input/slider/Slider.java
@@ -48,7 +48,7 @@ public class Slider extends Widget implements HasValue<Integer>, LeafValueEditor
     @Override
     public void onTouchStart(TouchStartEvent event) {
       setValueContrained(event.getTouches().get(0).getClientX());
-      if (MGWT.getFormFactor().isDesktop()) {
+      if (MGWT.getFormFactor().isDesktop() || MGWT.getOsDetection().isWindowsPhone()) {
         DOM.setCapture(getElement());
       }
       event.stopPropagation();
@@ -65,7 +65,7 @@ public class Slider extends Widget implements HasValue<Integer>, LeafValueEditor
 
     @Override
     public void onTouchEnd(TouchEndEvent event) {
-      if (MGWT.getFormFactor().isDesktop()) {
+      if (MGWT.getFormFactor().isDesktop() || MGWT.getOsDetection().isWindowsPhone()) {
         DOM.releaseCapture(getElement());
       }
       event.stopPropagation();
@@ -74,7 +74,7 @@ public class Slider extends Widget implements HasValue<Integer>, LeafValueEditor
 
     @Override
     public void onTouchCancel(TouchCancelEvent event) {
-      if (MGWT.getFormFactor().isDesktop()) {
+      if (MGWT.getFormFactor().isDesktop() || MGWT.getOsDetection().isWindowsPhone()) {
         DOM.releaseCapture(getElement());
       }
     }

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/input/slider/Slider.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/input/slider/Slider.java
@@ -30,9 +30,8 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.HasValue;
 import com.google.gwt.user.client.ui.Widget;
-
 import com.googlecode.mgwt.dom.client.event.touch.TouchHandler;
-import com.googlecode.mgwt.ui.client.MGWT;
+import com.googlecode.mgwt.ui.client.TouchSupport;
 import com.googlecode.mgwt.ui.client.util.CssUtil;
 import com.googlecode.mgwt.ui.client.widget.touch.TouchWidgetImpl;
 
@@ -48,7 +47,7 @@ public class Slider extends Widget implements HasValue<Integer>, LeafValueEditor
     @Override
     public void onTouchStart(TouchStartEvent event) {
       setValueContrained(event.getTouches().get(0).getClientX());
-      if (MGWT.getFormFactor().isDesktop() || MGWT.getOsDetection().isWindowsPhone()) {
+      if (TouchSupport.isTouchEventsEmulatedUsingMouseEvents()) {
         DOM.setCapture(getElement());
       }
       event.stopPropagation();
@@ -65,7 +64,7 @@ public class Slider extends Widget implements HasValue<Integer>, LeafValueEditor
 
     @Override
     public void onTouchEnd(TouchEndEvent event) {
-      if (MGWT.getFormFactor().isDesktop() || MGWT.getOsDetection().isWindowsPhone()) {
+      if (TouchSupport.isTouchEventsEmulatedUsingMouseEvents()) {
         DOM.releaseCapture(getElement());
       }
       event.stopPropagation();
@@ -74,7 +73,7 @@ public class Slider extends Widget implements HasValue<Integer>, LeafValueEditor
 
     @Override
     public void onTouchCancel(TouchCancelEvent event) {
-      if (MGWT.getFormFactor().isDesktop() || MGWT.getOsDetection().isWindowsPhone()) {
+      if (TouchSupport.isTouchEventsEmulatedUsingMouseEvents()) {
         DOM.releaseCapture(getElement());
       }
     }

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/list/celllist/CellList.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/list/celllist/CellList.java
@@ -13,6 +13,8 @@
  */
 package com.googlecode.mgwt.ui.client.widget.list.celllist;
 
+import java.util.List;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.EventTarget;
@@ -29,13 +31,11 @@ import com.google.gwt.uibinder.client.UiFactory;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Widget;
-
 import com.googlecode.mgwt.dom.client.event.tap.Tap;
 import com.googlecode.mgwt.dom.client.event.touch.TouchHandler;
 import com.googlecode.mgwt.dom.client.recognizer.EventPropagator;
+import com.googlecode.mgwt.ui.client.MGWT;
 import com.googlecode.mgwt.ui.client.widget.touch.TouchWidgetImpl;
-
-import java.util.List;
 
 /**
  *
@@ -123,7 +123,12 @@ public class CellList<T> extends Widget implements HasCellSelectedHandler {
         return;
       }
 
-      event.preventDefault();
+      // if windows phone then do not prevent default, causes scrolling issues when
+      // in scroll panel (not sure why), ie10 desktop is fine
+      if (!MGWT.getOsDetection().isWindowsPhone())
+      {
+        event.preventDefault();
+      }
 
       // text node use the parent..
       if (Node.is(eventTarget) && !Element.is(eventTarget)) {

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/list/celllist/celllist.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/list/celllist/celllist.css
@@ -71,6 +71,12 @@
   }
 }
 
+@if user.agent ie10 {
+  .mgwt-List-Head-Element, .mgwt-List > .mgwt-List-Head-Element {
+    background-color: #288ede;
+  }
+}
+
 @if user.agent gecko1_8 {
   .mgwt-List-Head-Element, .mgwt-List > .mgwt-List-Head-Element {
     background-color: #288ede;

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/list/celllist/grouping-celllist.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/list/celllist/grouping-celllist.css
@@ -9,6 +9,12 @@
   }
 }
 
+@if user.agent ie10 {
+  .mgwt-GroupingList {
+    display: -ms-flexbox;
+  }
+}
+
 @if user.agent gecko1_8 {
   .mgwt-GroupingList {
     display: -moz-box;
@@ -45,6 +51,13 @@
 	}
 }
 
+@if user.agent ie10 {
+  .mgwt-GroupingList-Selection-Bar {
+    display: -ms-flexbox;
+    -ms-flex-direction: column;
+	}
+}
+
 @if user.agent gecko1_8 {
   .mgwt-GroupingList-Selection-Bar {
     display: -moz-box;
@@ -66,6 +79,12 @@
 @if user.agent safari {
   .mgwt-GroupingList-Selection-Bar > li{
     -webkit-box-flex: 1;
+  }
+}
+
+@if user.agent ie10 {
+  .mgwt-GroupingList-Selection-Bar > li{
+    -ms-flex: 1;
   }
 }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/list/celllist/grouping-celllist.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/list/celllist/grouping-celllist.css
@@ -84,7 +84,7 @@
 
 @if user.agent ie10 {
   .mgwt-GroupingList-Selection-Bar > li{
-    -ms-flex: 1;
+    -ms-flex: 1 1;
   }
 }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/list/widgetlist/widgetlist.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/list/widgetlist/widgetlist.css
@@ -43,7 +43,7 @@
   }
 }
 
-@if user.agent safari {
+@if user.agent ie10 {
   .mgwt-WidgetList-Entry {
     display: -ms-flexbox;
   }

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/list/widgetlist/widgetlist.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/list/widgetlist/widgetlist.css
@@ -43,6 +43,12 @@
   }
 }
 
+@if user.agent safari {
+  .mgwt-WidgetList-Entry {
+    display: -ms-flexbox;
+  }
+}
+
 @if user.agent gecko1_8 {
   .mgwt-WidgetList-Entry {
     width: 100%;

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/main/IOS71BodyBug.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/main/IOS71BodyBug.java
@@ -45,30 +45,36 @@ public class IOS71BodyBug {
     TextResource css();
   }
 
+  /**
+   * Only apply fix if ios71
+   */
   public static void applyWorkaround() {
-    // iOS bug fix needs only be applied in portrait orientation.
-    // Fix is deferred until the orientation change event is fired.
-    if (MGWT.getOrientation() == ORIENTATION.PORTRAIT) {
-      registerOrientationChangeEvent();
-      return;
+    if (isIOS71() && (MGWT.getOsDetection().isIPad() || MGWT.getOsDetection().isIPadRetina())) {
+      // iOS bug fix needs only be applied in portrait orientation.
+      // Fix is deferred until the orientation change event is fired.
+      if (MGWT.getOrientation() == ORIENTATION.PORTRAIT) {
+        registerOrientationChangeEvent();
+        return;
+      }
+      applyFix();
     }
+  }
 
-    if (MGWT.getOsDetection().isIPad() || MGWT.getOsDetection().isIPadRetina()) {
-      if (isIOS71() && windowInnerHeight() == 672) {
+  private static void applyFix() {
+      if (windowInnerHeight() == 672) {
         String text = Resources.INSTANCE.css().getText();
         StyleInjector.inject(text);
         Document.get().getBody().addClassName("__fixIOS7BodyBug");
       }
-    }
   }
-
   private static void registerOrientationChangeEvent() {
     orientationChangeHandler = MGWT.addOrientationChangeHandler(new OrientationChangeHandler() {
 
       @Override
       public void onOrientationChanged(OrientationChangeEvent event) {
+        orientationChangeHandler.removeHandler();
         orientationChangeHandler = null;
-        applyWorkaround();
+        applyFix();
       }
     });
   }

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/main/main.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/main/main.css
@@ -1,39 +1,39 @@
 @external body, *;
+
 * {
-  -webkit-text-size-adjust: none;
-  -webkit-touch-callout: none;
-  -webkit-text-size-adjust: none;
   margin: 0px;
   padding: 0px;
   font-family: Helvetica, sans-serif;
 }
 
-
-body {
-  margin: 0;
-  padding: 0;
-  background: #dfe2e2;
-  color: #000;
-  font-weight: 400;
-  -webkit-perspective: 800;
-  -webkit-transform-style: preserve-3d;
-  position: absolute;
-  width: 100%;
-  height: 100%;
-}
-
-:focus {
-  outline-color: transparent;
-  outline-style: none;
-}
-
-@if user.agent gecko1_8 {
-  * {
-    -webkit-user-select: none;
+@if user.agent safari {
+* {
+  -webkit-text-size-adjust: none;
+  -webkit-touch-callout: none;
+  -webkit-text-size-adjust: none;
+  -webkit-user-select: none;
   }
 
-  input, textarea {
+  input , textarea{
     -webkit-user-select: text;
+  }
+}
+
+@if user.agent ie10 {
+  * {
+     -ms-user-select: none;
+     -ms-text-size-adjust: none;
+     -ms-touch-select: none;
+     -ms-touch-action: none;
+     -ms-flex: 0 1 auto;
+  }
+  
+  input , textarea{
+    -ms-user-select: text;
+  }
+
+  a img {
+      border: none;
   }
 }
 
@@ -45,6 +45,33 @@ body {
   input, textarea {
     -moz-user-select: text;
   }
+}
+
+
+@if user.agent safari {
+body {
+  -webkit-perspective: 800;
+  -webkit-transform-style: preserve-3d;
+  }
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: #dfe2e2;
+  color: #000;
+  font-weight: 400;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  perspective: 800;
+  transform-style: preserve-3d;
+}
+
+
+:focus {
+  outline-color: transparent;
+  outline-style: none;
 }
 
 input:FOCUS,button:FOCUS {

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/main/main.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/main/main.css
@@ -24,7 +24,6 @@
      -ms-user-select: none;
      -ms-text-size-adjust: none;
      -ms-touch-select: none;
-     -ms-touch-action: none;
      -ms-flex: 0 1 auto;
   }
   

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/main/selection.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/main/selection.css
@@ -8,6 +8,12 @@
   }
 }
 
+@if user.agent ie10 {
+  .userSelectNone {
+    -ms-user-select: none;
+  }
+}
+
 @if user.agent gecko1_8 {
   .userSelectNone {
     -moz-user-select: none;
@@ -23,6 +29,12 @@
 @if user.agent safari {
   .userSelectText {
     -webkit-user-select: text;
+  }
+}
+
+@if user.agent ie10 {
+  .userSelectText {
+    -ms-user-select: text;
   }
 }
 
@@ -44,6 +56,12 @@
   }
 }
 
+@if user.agent ie10 {
+  .userSelectAll {
+    -ms-user-select: all;
+  }
+}
+
 @if user.agent gecko1_8 {
   .userSelectAll {
     -moz-user-select: all;
@@ -59,6 +77,12 @@
 @if user.agent safari {
   .userSelectElement {
     -webkit-user-select: element;
+  }
+}
+
+@if user.agent ie10 {
+  .userSelectElement {
+    -ms-user-select: element;
   }
 }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/main/util.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/main/util.css
@@ -1,11 +1,11 @@
 @media (orientation:portrait) {
 	.landscapeonly {
-		display: none;
+		display: none !important;
 	}
 }
 
 @media (orientation:landscape) {
 	.portraitonly {
-		display: none;
+		display: none !important;
 	}
 }

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/menu/overlay/overlay-menu.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/menu/overlay/overlay-menu.css
@@ -39,18 +39,27 @@
 
 @if user.agent safari {
   .mgwt-OverlayMenu-nav {
-    -webkit-transform-property: opacity;
+    -webkit-transition-property: opacity;
   }
   .mgwt-OverlayMenu-main {
-    -webkit-transform-property: left;
+    -webkit-transition-property: left;
+  }
+}
+
+@if user.agent ie10 {
+  .mgwt-OverlayMenu-nav {
+    transition-property: opacity;
+  }
+  .mgwt-OverlayMenu-main {
+    transition-property: left;
   }
 }
 
 @if user.agent gecko1_8 {
   .mgwt-OverlayMenu-nav {
-    -moz-transform-property: opacity;
+    -moz-transition-property: opacity;
   }
   .mgwt-OverlayMenu-main {
-    -moz-transform-property: left;
+    -moz-transition-property: left;
   }
 }

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/menu/swipe/swipe-menu.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/menu/swipe/swipe-menu.css
@@ -40,6 +40,15 @@
   }
 }
 
+@if user.agent ie10 {
+  .opened {
+    transform: translate3d(0, 0, 0);
+  }
+  .closed {
+    transform: translate3d(-40%, 0, 0);
+  }
+}
+
 @if user.agent gecko1_8 {
   .opened {
     -moz-transform: translate3d(0, 0, 0);

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPanel.gwt.xml
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPanel.gwt.xml
@@ -15,4 +15,30 @@ under * the License.
   <replace-with class="com.googlecode.mgwt.ui.client.widget.panel.flex.FlexPanelDefaultAppearance">
     <when-type-is class="com.googlecode.mgwt.ui.client.widget.panel.flex.FlexPanelAppearance" />
   </replace-with>
+
+  <replace-with class="com.googlecode.mgwt.ui.client.widget.panel.flex.FlexPropertyHelperStandard">
+    <when-type-is class="com.googlecode.mgwt.ui.client.widget.panel.flex.FlexPropertyHelper" />
+  </replace-with>
+
+  <replace-with class="com.googlecode.mgwt.ui.client.widget.panel.flex.FlexPropertyHelperWebkit">
+    <when-type-is class="com.googlecode.mgwt.ui.client.widget.panel.flex.FlexPropertyHelper" />
+    <all>
+      <when-property-is name="user.agent" value="safari" />
+    </all>
+  </replace-with>
+
+  <replace-with class="com.googlecode.mgwt.ui.client.widget.panel.flex.FlexPropertyHelperIE10">
+    <when-type-is class="com.googlecode.mgwt.ui.client.widget.panel.flex.FlexPropertyHelper" />
+    <all>
+      <when-property-is name="user.agent" value="ie10" />
+    </all>
+  </replace-with>
+
+  <replace-with class="com.googlecode.mgwt.ui.client.widget.panel.flex.FlexPropertyHelperMoz">
+    <when-type-is class="com.googlecode.mgwt.ui.client.widget.panel.flex.FlexPropertyHelper" />
+    <all>
+      <when-property-is name="user.agent" value="gecko1_8" />
+    </all>
+  </replace-with>
+  
 </module>

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelper.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelper.java
@@ -35,7 +35,7 @@ public abstract class FlexPropertyHelper {
   }
   
   public static enum Orientation {
-    HORIZONTAL, VERTICAL;
+    HORIZONTAL, HORIZONTAL_REVERSE, VERTICAL, VERTICAL_REVERSE;
   }
 
   public static void setElementAsFlexContainer(Element el)

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelper.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelper.java
@@ -15,160 +15,97 @@
  */
 package com.googlecode.mgwt.ui.client.widget.panel.flex;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Element;
 
-public final class FlexPropertyHelper {
+public abstract class FlexPropertyHelper {
 
+  private static final FlexPropertyHelper impl = GWT.create(FlexPropertyHelper.class);
+  
   public static enum Alignment {
-    START("flex-start"), END("flex-end"), CENTER("center"), STRETCH("stretch"), BASELINE("baseline");
+    START, END, CENTER, STRETCH, BASELINE, NONE;
+  }
 
-    private final String cssValue;
-
-    private Alignment(String cssValue) {
-      this.cssValue = cssValue;
-    }
-
-    private static String getCssProperty() {
-      return "AlignItems";
-    }
-
-    private String getCssValue() {
-      return cssValue;
-    }
+  public static enum AlignmentSelf {
+    START, END, CENTER, STRETCH, BASELINE, AUTO;
   }
 
   public static enum Justification {
-    START("flex-start"), END("flex-end"), CENTER("center"), SPACE_BETWEEN("space-between"), SPACE_AROUND("space-around");
-
-    private final String cssValue;
-
-    private Justification(String cssValue) {
-      this.cssValue = cssValue;
-    }
-
-    private static String getCssProperty() {
-      return "JustifyContent";
-    }
-
-    private String getCssValue() {
-      return cssValue;
-    }
+    START, END, CENTER, SPACE_BETWEEN, SPACE_AROUND, NONE;
   }
-
+  
   public static enum Orientation {
-    HORIZONTAL("row"), VERTICAL("column");
+    HORIZONTAL, VERTICAL;
+  }
 
-    private final String cssValue;
-
-    private Orientation(String cssValue) {
-      this.cssValue = cssValue;
+  public static void setElementAsFlexContainer(Element el)
+  {
+    setElementAsFlexContainer(el, null);
+  }
+  
+  public static void setElementAsFlexContainer(Element el, Orientation orientation)
+  {
+    if (orientation == null)
+    {
+      orientation = Orientation.HORIZONTAL; // the default
     }
-
-    private static String getCssProperty() {
-      return "Direction";
-    }
-
-    private String getCssValue() {
-      return cssValue;
-    }
+    impl._setElementAsFlexContainer(el, orientation);
   }
 
-  public static void setFlex(Element el, double flex) {
-    /* iOS < 7 && Android < 4.4*/
-    el.getStyle().setProperty("WebkitBoxFlex", Double.toString(flex));
-
-    el.getStyle().setProperty("MozFlex", Double.toString(flex));
-    el.getStyle().setProperty("WebkitFlex", Double.toString(flex));
-    el.getStyle().setProperty("flex", Double.toString(flex));
+  public static void setFlex(Element el, double grow) {
+    setFlex(el, grow, "0%");
   }
 
-  private static void setFlexProperty(Element el, String name, String value) {
-    setStyleProperty(el, "MozFlex" + name, value);
-    setStyleProperty(el, "WebkitFlex" + name, value);
-    setStyleProperty(el, "flex" + name, value);
+  public static void setFlex(Element el, double grow, double shrink) {
+    setFlex(el, grow, shrink, "0%");
   }
 
-  private static void setProperty(Element el, String name, String value) {
-    setStyleProperty(el, "Moz" + name, value);
-    setStyleProperty(el, "Webkit" + name, value);
-    setStyleProperty(el, name, value);
+  public static void setFlex(Element el, double grow, double shrink, String basis) {
+    impl._setFlex(el, grow, shrink, basis);
   }
 
-  public static void setOrientation(Element el, Orientation value) {
-    // iOS6 & Android < 4.4
-    switch (value) {
-      case HORIZONTAL:
-        el.getStyle().setProperty("WebkitBoxOrient", "horizontal");
-        break;
-      case VERTICAL:
-        el.getStyle().setProperty("WebkitBoxOrient", "vertical");
-        break;
-      default:
-        throw new RuntimeException();
-    }
-    setFlexProperty(el, Orientation.getCssProperty(), value.getCssValue());
+  public static void setFlex(Element el, double grow, String basis) {
+    impl._setFlex(el, grow, basis);
   }
 
-  public static void setAlignment(Element el, Alignment value) {
-    // iOS6 & Android < 4.4
-    switch (value) {
-      case START:
-        el.getStyle().setProperty("WebkitBoxAlign", "start");
-        break;
-      case CENTER:
-        el.getStyle().setProperty("WebkitBoxAlign", "center");
-        break;
-      case END:
-        el.getStyle().setProperty("WebkitBoxAlign", "end");
-        break;
-      case BASELINE:
-        el.getStyle().setProperty("WebkitBoxAlign", "baseline");
-        break;
-      case STRETCH:
-        el.getStyle().setProperty("WebkitBoxAlign", "stretch");
-        break;
-      default:
-        throw new RuntimeException();
-    }
-    setProperty(el, Alignment.getCssProperty(), value.getCssValue());
+  public static void setFlexOrder(Element el, int order) {
+    impl._setFlexOrder(el, order);
   }
 
-  public static void setJustification(Element el, Justification value) {
-    // iOS6 & Android < 4.4
-    switch (value) {
-      case START:
-        el.getStyle().setProperty("WebkitBoxPack", "start");
-        break;
-      case CENTER:
-        el.getStyle().setProperty("WebkitBoxPack", "center");
-        break;
-      case END:
-        el.getStyle().setProperty("WebkitBoxPack", "end");
-        break;
-      case SPACE_BETWEEN:
-        el.getStyle().setProperty("WebkitBoxPack", "justify");
-        break;
-      case SPACE_AROUND:
-          el.getStyle().setProperty("WebkitBoxPack", "justify");
-          break;
-      default:
-        throw new RuntimeException();
-    }
-    setProperty(el, Justification.getCssProperty(), value.getCssValue());
+  public static void setAlignment(Element el, Alignment alignment) {
+    impl._setAlignmentProperty(el, alignment);
   }
 
-  private static void setStyleProperty(Element el, String property, String value) {
+  public static void setAlignmentSelf(Element el, AlignmentSelf alignmentSelf) {
+    impl._setAlignmentSelfProperty(el, alignmentSelf);
+  }
+
+  public static void setOrientation(Element el, Orientation orientation) {
+    impl._setOrientationProperty(el, orientation);
+  }
+
+  public static void setJustification(Element el, Justification justification) {
+    impl._setJustificationProperty(el, justification);
+  }
+
+  public static void clearAlignment(Element el) {
+    impl._setAlignmentProperty(el,Alignment.NONE);
+  }
+
+  public static void clearJustification(Element el) {
+    impl._setJustificationProperty(el,Justification.NONE);
+  }
+  
+  protected void setStyleProperty(Element el, String property, String value) {
     el.getStyle().setProperty(property, value);
   }
 
-  private FlexPropertyHelper() {
-  }
-
-  public static void clearAlignment(Element element) {
-    setProperty(element, Alignment.getCssProperty(), "");
-  }
-
-  public static void clearJustification(Element element) {
-    setProperty(element, Justification.getCssProperty(), "");
-  }
+  protected abstract void _setElementAsFlexContainer(Element el, Orientation orientation);
+  protected abstract void _setFlex(Element el, double grow, String basis);
+  protected abstract void _setFlex(Element el, double grow, double shrink, String basis);
+  protected abstract void _setFlexOrder(Element el, int order);
+  protected abstract void _setAlignmentProperty(Element el, Alignment alignment);
+  protected abstract void _setAlignmentSelfProperty(Element el, AlignmentSelf alignmentSelf);
+  protected abstract void _setOrientationProperty(Element el, Orientation orientation);
+  protected abstract void _setJustificationProperty(Element el, Justification justification);
 }

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelper.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelper.java
@@ -38,6 +38,10 @@ public abstract class FlexPropertyHelper {
     HORIZONTAL, HORIZONTAL_REVERSE, VERTICAL, VERTICAL_REVERSE;
   }
 
+  public static enum FlexWrap {
+    NOWRAP, WRAP, WRAP_REVERSE;
+  }
+
   public static void setElementAsFlexContainer(Element el)
   {
     setElementAsFlexContainer(el, null);
@@ -88,6 +92,10 @@ public abstract class FlexPropertyHelper {
     impl._setJustificationProperty(el, justification);
   }
 
+  public static void setFlexWrap(Element el, FlexWrap flexWrap) {
+    impl._setFlexWrapProperty(el, flexWrap);
+  }
+
   public static void clearAlignment(Element el) {
     impl._setAlignmentProperty(el,Alignment.NONE);
   }
@@ -108,4 +116,5 @@ public abstract class FlexPropertyHelper {
   protected abstract void _setAlignmentSelfProperty(Element el, AlignmentSelf alignmentSelf);
   protected abstract void _setOrientationProperty(Element el, Orientation orientation);
   protected abstract void _setJustificationProperty(Element el, Justification justification);
+  protected abstract void _setFlexWrapProperty(Element el, FlexWrap flexWrap);
 }

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperIE10.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperIE10.java
@@ -1,0 +1,147 @@
+package com.googlecode.mgwt.ui.client.widget.panel.flex;
+
+import com.google.gwt.dom.client.Element;
+
+/**
+ * Unbelievable - IE10 does not obey the camel case rule correctly
+ * @author pfrench
+ *
+ */
+public class FlexPropertyHelperIE10 extends FlexPropertyHelper {
+
+  @Override
+  public void _setAlignmentProperty(Element el, Alignment alignment) {
+    String value;
+    switch (alignment) {
+      case START: {
+        value = "start";
+        break;
+      }
+      case END: {
+        value = "end";
+        break;
+      }
+      case CENTER: {
+        value = "center";
+        break;
+      }
+      case STRETCH: {
+        value = "stretch";
+        break;
+      }
+      case BASELINE: {
+        value = "baseline";
+        break;
+      }
+      default: {
+        value = "";
+      }
+    }
+    setStyleProperty(el, "msFlexAlign", value);
+  }
+
+  @Override
+  public void _setOrientationProperty(Element el, Orientation orientation) {
+    String value;
+    switch (orientation) {
+      case HORIZONTAL: {
+        value = "row";
+        break;
+      }
+      case VERTICAL: {
+        value = "column";
+        break;
+      }
+      default: {
+        value = "";
+        break;
+      }
+    }
+    setStyleProperty(el, "msFlexDirection", value);
+  }
+
+  @Override
+  public void _setJustificationProperty(Element el, Justification justification) {
+    String value;
+    switch (justification) {
+      case START: {
+        value = "start";
+        break;
+      }
+      case END: {
+        value = "end";
+        break;
+      }
+      case CENTER: {
+        value = "center";
+        break;
+      }
+      case SPACE_AROUND: {
+        value = "distribute";
+        break;
+      }
+      case SPACE_BETWEEN: {
+        value = "justify";
+        break;
+      }
+      default: {
+        value = "";
+      }
+    }
+    setStyleProperty(el, "msFlexPack", value);
+  }
+
+  @Override
+  protected void _setAlignmentSelfProperty(Element el, AlignmentSelf alignmentSelf)
+  {
+    String value;
+    switch (alignmentSelf) {
+      case START: {
+        value = "start";
+        break;
+      }
+      case END: {
+        value = "end";
+        break;
+      }
+      case CENTER: {
+        value = "center";
+        break;
+      }
+      case STRETCH: {
+        value = "stretch";
+        break;
+      }
+      case BASELINE: {
+        value = "baseline";
+        break;
+      }
+      default: {
+        value = "auto";
+      }
+    }
+    setStyleProperty(el, "msFlexItemAlign", value);
+  }
+
+  @Override
+  protected void _setFlex(Element el, double grow, String basis) {
+    setStyleProperty(el,"msFlex", Double.toString(grow)+" "+(basis == null ? "0%" : basis));
+  }
+
+  @Override
+  protected void _setFlex(Element el, double grow, double shrink, String basis) {
+    setStyleProperty(el,"msFlex", Double.toString(grow)+" "+Double.toString(shrink)+" "+(basis == null ? "0%" : basis));
+  }
+
+  @Override
+  public void _setFlexOrder(Element el, int order) {
+    setStyleProperty(el,"msFlexOrder", Integer.toString(order));
+  }
+
+  @Override
+  protected void _setElementAsFlexContainer(Element el, Orientation orientation) {
+    setStyleProperty(el,"display", "-ms-flexbox");
+    _setOrientationProperty(el,orientation);
+  }
+
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperIE10.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperIE10.java
@@ -131,6 +131,32 @@ public class FlexPropertyHelperIE10 extends FlexPropertyHelper {
     setStyleProperty(el, "msFlexItemAlign", value);
   }
 
+  @Override
+  protected void _setFlexWrapProperty(Element el, FlexWrap flexWrap)
+  {
+    String value;
+    switch (flexWrap) {
+      case NOWRAP: {
+        value = "nowrap";
+        break;
+      }
+      case WRAP: {
+        value = "wrap";
+        break;
+      }
+      case WRAP_REVERSE: {
+        value = "wrap-reverse";
+        break;
+      }
+      default: {
+        value = "nowrap";
+        break;
+      }
+    }
+    setStyleProperty(el, "msFlexWrap", value);
+  }
+
+
   /**
    * IE10/11 sets flex-shrink to 0 if omitted whereas webkit sets to 1, so lets copy webkit
    */

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperIE10.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperIE10.java
@@ -52,6 +52,14 @@ public class FlexPropertyHelperIE10 extends FlexPropertyHelper {
         value = "column";
         break;
       }
+      case HORIZONTAL_REVERSE: {
+        value = "row-reverse";
+        break;
+      }
+      case VERTICAL_REVERSE: {
+        value = "column-reverse";
+        break;
+      }
       default: {
         value = "";
         break;
@@ -123,9 +131,12 @@ public class FlexPropertyHelperIE10 extends FlexPropertyHelper {
     setStyleProperty(el, "msFlexItemAlign", value);
   }
 
+  /**
+   * IE10/11 sets flex-shrink to 0 if omitted whereas webkit sets to 1, so lets copy webkit
+   */
   @Override
   protected void _setFlex(Element el, double grow, String basis) {
-    setStyleProperty(el,"msFlex", Double.toString(grow)+" "+(basis == null ? "0%" : basis));
+    _setFlex(el,grow,1,basis);
   }
 
   @Override

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperMoz.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperMoz.java
@@ -1,0 +1,142 @@
+package com.googlecode.mgwt.ui.client.widget.panel.flex;
+
+import com.google.gwt.dom.client.Element;
+
+public class FlexPropertyHelperMoz extends FlexPropertyHelper {
+
+  @Override
+  public void _setAlignmentProperty(Element el, Alignment alignment) {
+    String value;
+    switch (alignment) {
+      case START: {
+        value = "flex-start";
+        break;
+      }
+      case END: {
+        value = "flex-end";
+        break;
+      }
+      case CENTER: {
+        value = "center";
+        break;
+      }
+      case STRETCH: {
+        value = "stretch";
+        break;
+      }
+      case BASELINE: {
+        value = "baseline";
+        break;
+      }
+      default: {
+        value = "";
+      }
+    }
+    setStyleProperty(el, "MozAlignItems", value);
+  }
+
+  @Override
+  public void _setOrientationProperty(Element el, Orientation orientation) {
+    String value;
+    switch (orientation) {
+      case HORIZONTAL: {
+        value = "row";
+        break;
+      }
+      case VERTICAL: {
+        value = "column";
+        break;
+      }
+      default: {
+        value = "";
+        break;
+      }
+    }
+    setStyleProperty(el, "MozFlexDirection", value);
+  }
+
+  @Override
+  public void _setJustificationProperty(Element el, Justification justification) {
+    String value;
+    switch (justification) {
+      case START: {
+        value = "flex-start";
+        break;
+      }
+      case END: {
+        value = "flex-end";
+        break;
+      }
+      case CENTER: {
+        value = "center";
+        break;
+      }
+      case SPACE_AROUND: {
+        value = "space-around";
+        break;
+      }
+      case SPACE_BETWEEN: {
+        value = "space-between";
+        break;
+      }
+      default: {
+        value = "";
+      }
+    }
+    setStyleProperty(el, "MozJustifyContent", value);
+  }
+
+  @Override
+  protected void _setAlignmentSelfProperty(Element el, AlignmentSelf alignmentSelf)
+  {
+    String value;
+    switch (alignmentSelf) {
+      case START: {
+        value = "flex-start";
+        break;
+      }
+      case END: {
+        value = "flex-end";
+        break;
+      }
+      case CENTER: {
+        value = "center";
+        break;
+      }
+      case STRETCH: {
+        value = "stretch";
+        break;
+      }
+      case BASELINE: {
+        value = "baseline";
+        break;
+      }
+      default: {
+        value = "auto";
+      }
+    }
+    setStyleProperty(el, "alignSelf", value);
+  }
+
+  @Override
+  protected void _setFlex(Element el, double grow, String basis) {
+    setStyleProperty(el,"MozFlex", Double.toString(grow)+" "+(basis == null ? "0%" : basis));
+  }
+
+  @Override
+  protected void _setFlex(Element el, double grow, double shrink, String basis) {
+    setStyleProperty(el,"MozFlex", Double.toString(grow)+" "+Double.toString(shrink)+" "+(basis == null ? "0%" : basis));
+  }
+
+  @Override
+  public void _setFlexOrder(Element el, int order) {
+    setStyleProperty(el,"MozOrder", Integer.toString(order));
+  }
+
+  @Override
+  protected void _setElementAsFlexContainer(Element el, Orientation orientation) {
+    setStyleProperty(el,"display", "-moz-flex");
+    _setOrientationProperty(el,orientation);
+  }
+
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperMoz.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperMoz.java
@@ -47,6 +47,14 @@ public class FlexPropertyHelperMoz extends FlexPropertyHelper {
         value = "column";
         break;
       }
+      case HORIZONTAL_REVERSE: {
+        value = "row-reverse";
+        break;
+      }
+      case VERTICAL_REVERSE: {
+        value = "column-reverse";
+        break;
+      }
       default: {
         value = "";
         break;

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperMoz.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperMoz.java
@@ -123,7 +123,32 @@ public class FlexPropertyHelperMoz extends FlexPropertyHelper {
         value = "auto";
       }
     }
-    setStyleProperty(el, "alignSelf", value);
+    setStyleProperty(el, "MozAlignSelf", value);
+  }
+
+  @Override
+  protected void _setFlexWrapProperty(Element el, FlexWrap flexWrap)
+  {
+    String value;
+    switch (flexWrap) {
+      case NOWRAP: {
+        value = "nowrap";
+        break;
+      }
+      case WRAP: {
+        value = "wrap";
+        break;
+      }
+      case WRAP_REVERSE: {
+        value = "wrap-reverse";
+        break;
+      }
+      default: {
+        value = "nowrap";
+        break;
+      }
+    }
+    setStyleProperty(el, "MozFlexWrap", value);
   }
 
   @Override

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperStandard.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperStandard.java
@@ -127,6 +127,31 @@ public class FlexPropertyHelperStandard extends FlexPropertyHelper {
   }
 
   @Override
+  protected void _setFlexWrapProperty(Element el, FlexWrap flexWrap)
+  {
+    String value;
+    switch (flexWrap) {
+      case NOWRAP: {
+        value = "nowrap";
+        break;
+      }
+      case WRAP: {
+        value = "wrap";
+        break;
+      }
+      case WRAP_REVERSE: {
+        value = "wrap-reverse";
+        break;
+      }
+      default: {
+        value = "nowrap";
+        break;
+      }
+    }
+    setStyleProperty(el, "flexWrap", value);
+  }
+
+  @Override
   protected void _setFlex(Element el, double grow, String basis) {
     setStyleProperty(el,"flex", Double.toString(grow)+" "+(basis == null ? "0%" : basis));
   }

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperStandard.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperStandard.java
@@ -1,0 +1,142 @@
+package com.googlecode.mgwt.ui.client.widget.panel.flex;
+
+import com.google.gwt.dom.client.Element;
+
+public class FlexPropertyHelperStandard extends FlexPropertyHelper {
+
+  @Override
+  public void _setAlignmentProperty(Element el, Alignment alignment) {
+    String value;
+    switch (alignment) {
+      case START: {
+        value = "flex-start";
+        break;
+      }
+      case END: {
+        value = "flex-end";
+        break;
+      }
+      case CENTER: {
+        value = "center";
+        break;
+      }
+      case STRETCH: {
+        value = "stretch";
+        break;
+      }
+      case BASELINE: {
+        value = "baseline";
+        break;
+      }
+      default: {
+        value = "";
+      }
+    }
+    setStyleProperty(el, "alignItems", value);
+  }
+
+  @Override
+  public void _setOrientationProperty(Element el, Orientation orientation) {
+    String value;
+    switch (orientation) {
+      case HORIZONTAL: {
+        value = "row";
+        break;
+      }
+      case VERTICAL: {
+        value = "column";
+        break;
+      }
+      default: {
+        value = "";
+        break;
+      }
+    }
+    setStyleProperty(el, "flexDirection", value);
+  }
+
+  @Override
+  public void _setJustificationProperty(Element el, Justification justification) {
+    String value;
+    switch (justification) {
+      case START: {
+        value = "flex-start";
+        break;
+      }
+      case END: {
+        value = "flex-end";
+        break;
+      }
+      case CENTER: {
+        value = "center";
+        break;
+      }
+      case SPACE_AROUND: {
+        value = "space-around";
+        break;
+      }
+      case SPACE_BETWEEN: {
+        value = "space-between";
+        break;
+      }
+      default: {
+        value = "";
+      }
+    }
+    setStyleProperty(el, "justifyContent", value);
+  }
+
+  @Override
+  protected void _setAlignmentSelfProperty(Element el, AlignmentSelf alignmentSelf)
+  {
+    String value;
+    switch (alignmentSelf) {
+      case START: {
+        value = "flex-start";
+        break;
+      }
+      case END: {
+        value = "flex-end";
+        break;
+      }
+      case CENTER: {
+        value = "center";
+        break;
+      }
+      case STRETCH: {
+        value = "stretch";
+        break;
+      }
+      case BASELINE: {
+        value = "baseline";
+        break;
+      }
+      default: {
+        value = "auto";
+      }
+    }
+    setStyleProperty(el, "alignSelf", value);
+  }
+
+  @Override
+  protected void _setFlex(Element el, double grow, String basis) {
+    setStyleProperty(el,"flex", Double.toString(grow)+" "+(basis == null ? "0%" : basis));
+  }
+
+  @Override
+  protected void _setFlex(Element el, double grow, double shrink, String basis) {
+    setStyleProperty(el,"flex", Double.toString(grow)+" "+Double.toString(shrink)+" "+(basis == null ? "0%" : basis));
+  }
+
+  @Override
+  public void _setFlexOrder(Element el, int order) {
+    setStyleProperty(el,"order", Integer.toString(order));
+  }
+
+  @Override
+  protected void _setElementAsFlexContainer(Element el, Orientation orientation) {
+    setStyleProperty(el,"display", "flex");
+    _setOrientationProperty(el,orientation);
+  }
+
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperStandard.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperStandard.java
@@ -47,6 +47,14 @@ public class FlexPropertyHelperStandard extends FlexPropertyHelper {
         value = "column";
         break;
       }
+      case HORIZONTAL_REVERSE: {
+        value = "row-reverse";
+        break;
+      }
+      case VERTICAL_REVERSE: {
+        value = "column-reverse";
+        break;
+      }
       default: {
         value = "";
         break;

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperWebkit.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperWebkit.java
@@ -1,0 +1,165 @@
+package com.googlecode.mgwt.ui.client.widget.panel.flex;
+
+import com.google.gwt.dom.client.Element;
+
+public class FlexPropertyHelperWebkit extends FlexPropertyHelper {
+
+  @Override
+  public void _setAlignmentProperty(Element el, Alignment alignment) {
+    String alignItemOldSyntax, alignItemNewSyntax;
+    switch (alignment) {
+      case START: {
+        alignItemOldSyntax = "start";
+        alignItemNewSyntax = "flex-start";
+        break;
+      }
+      case END: {
+        alignItemOldSyntax = "end";
+        alignItemNewSyntax = "flex-end";
+        break;
+      }
+      case CENTER: {
+        alignItemOldSyntax = "center";
+        alignItemNewSyntax = "center";
+        break;
+      }
+      case STRETCH: {
+        alignItemOldSyntax = ""; // not implemented
+        alignItemNewSyntax = "stretch";
+        break;
+      }
+      case BASELINE: {
+        alignItemOldSyntax = "";  // not implemented
+        alignItemNewSyntax = "baseline";
+        break;
+      }
+      default: {
+        alignItemOldSyntax = "";
+        alignItemNewSyntax = "";
+      }
+    }
+    setStyleProperty(el, "WebkitBoxAlign", alignItemOldSyntax);
+    setStyleProperty(el, "WebkitAlignItems", alignItemNewSyntax);
+  }
+
+  @Override
+  public void _setOrientationProperty(Element el, Orientation orientation) {
+    String orientationOldSyntax, orientationNewSyntax;
+    switch (orientation) {
+      case HORIZONTAL: {
+        orientationOldSyntax = "horizontal";
+        orientationNewSyntax = "row";
+        break;
+      }
+      case VERTICAL: {
+        orientationOldSyntax = "vertical";
+        orientationNewSyntax = "column";
+        break;
+      }
+      default: {
+        orientationOldSyntax = "";
+        orientationNewSyntax = "";
+        break;
+      }
+    }
+    setStyleProperty(el, "WebkitBoxOrient", orientationOldSyntax);
+    setStyleProperty(el, "WebkitFlexDirection", orientationNewSyntax);
+  }
+
+  @Override
+  public void _setJustificationProperty(Element el, Justification justification) {
+    String justificationOldSyntax, justificationNewSyntax;
+    switch (justification) {
+      case START: {
+        justificationOldSyntax = "start";
+        justificationNewSyntax = "flex-start";
+        break;
+      }
+      case END: {
+        justificationOldSyntax = "end";
+        justificationNewSyntax = "flex-end";
+        break;
+      }
+      case CENTER: {
+        justificationOldSyntax = "center";
+        justificationNewSyntax = "center";
+        break;
+      }
+      case SPACE_AROUND: {
+        justificationOldSyntax = ""; // not implemented
+        justificationNewSyntax = "space-around";
+        break;
+      }
+      case SPACE_BETWEEN: {
+        justificationOldSyntax = "justify";
+        justificationNewSyntax = "space-between";
+        break;
+      }
+      default: {
+        justificationOldSyntax = "";
+        justificationNewSyntax = "";
+      }
+    }
+    setStyleProperty(el, "WebkitBoxPack", justificationOldSyntax);
+    setStyleProperty(el, "WebkitJustifyContent", justificationNewSyntax);
+  }
+
+  @Override
+  protected void _setAlignmentSelfProperty(Element el, AlignmentSelf alignmentSelf)
+  {
+    String value;
+    switch (alignmentSelf) {
+      case START: {
+        value = "flex-start";
+        break;
+      }
+      case END: {
+        value = "flex-end";
+        break;
+      }
+      case CENTER: {
+        value = "center";
+        break;
+      }
+      case STRETCH: {
+        value = "stretch";
+        break;
+      }
+      case BASELINE: {
+        value = "baseline";
+        break;
+      }
+      default: {
+        value = "auto";
+      }
+    }
+    setStyleProperty(el, "WebkitAlignSelf", value);
+  }
+
+  @Override
+  public void _setFlex(Element el, double grow, String basis) {
+    setStyleProperty(el,"WebkitBoxFlex", Double.toString(grow));
+    setStyleProperty(el,"WebkitFlex", Double.toString(grow)+(basis == null ? "0%" : basis));
+  }
+
+  @Override
+  protected void _setFlex(Element el, double grow, double shrink, String basis) {
+    setStyleProperty(el,"WebkitBoxFlex", Double.toString(grow)); // shrink and basis not supported
+    setStyleProperty(el,"WebkitFlex", Double.toString(grow)+" "+Double.toString(shrink)+" "+(basis == null ? "0%" : basis));
+  }
+
+  @Override
+  public void _setFlexOrder(Element el, int order) {
+    setStyleProperty(el,"WebkitBoxOrdinalGroup", Integer.toString(order));
+    setStyleProperty(el,"WebkitOrder", Integer.toString(order));
+  }
+
+
+  @Override
+  protected void _setElementAsFlexContainer(Element el, Orientation orientation) {
+    setStyleProperty(el,"display", "-webkit-box");
+    setStyleProperty(el,"display", "-webkit-flex");
+    _setOrientationProperty(el,orientation);
+  }
+
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperWebkit.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperWebkit.java
@@ -45,6 +45,7 @@ public class FlexPropertyHelperWebkit extends FlexPropertyHelper {
   @Override
   public void _setOrientationProperty(Element el, Orientation orientation) {
     String orientationOldSyntax, orientationNewSyntax;
+    boolean reverse = false;
     switch (orientation) {
       case HORIZONTAL: {
         orientationOldSyntax = "horizontal";
@@ -56,6 +57,16 @@ public class FlexPropertyHelperWebkit extends FlexPropertyHelper {
         orientationNewSyntax = "column";
         break;
       }
+      case HORIZONTAL_REVERSE: {
+        orientationOldSyntax = "horizontal"; reverse = true;
+        orientationNewSyntax = "row-reverse";
+        break;
+      }
+      case VERTICAL_REVERSE: {
+        orientationOldSyntax = "vertical"; reverse = true;
+        orientationNewSyntax = "column-reverse";
+        break;
+      }
       default: {
         orientationOldSyntax = "";
         orientationNewSyntax = "";
@@ -63,6 +74,7 @@ public class FlexPropertyHelperWebkit extends FlexPropertyHelper {
       }
     }
     setStyleProperty(el, "WebkitBoxOrient", orientationOldSyntax);
+    setStyleProperty(el, "WebkitBoxDirection", reverse ? "reverse" : "normal");
     setStyleProperty(el, "WebkitFlexDirection", orientationNewSyntax);
   }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperWebkit.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/FlexPropertyHelperWebkit.java
@@ -149,6 +149,36 @@ public class FlexPropertyHelperWebkit extends FlexPropertyHelper {
   }
 
   @Override
+  protected void _setFlexWrapProperty(Element el, FlexWrap flexWrap)
+  {
+    String flexWrapOldSyntax, flexWrapNewSyntax;
+    switch (flexWrap) {
+      case NOWRAP: {
+        flexWrapOldSyntax = "single";
+        flexWrapNewSyntax = "nowrap";
+        break;
+      }
+      case WRAP: {
+        flexWrapOldSyntax = "multiple";
+        flexWrapNewSyntax = "wrap";
+        break;
+      }
+      case WRAP_REVERSE: {
+        flexWrapOldSyntax = "multiple";
+        flexWrapNewSyntax = "wrap";
+        break;
+      }
+      default: {
+        flexWrapOldSyntax = "single";
+        flexWrapNewSyntax = "nowrap";
+        break;
+      }
+    }
+    setStyleProperty(el, "WebkitBoxLines", flexWrapOldSyntax);
+    setStyleProperty(el, "WebkitFlexWrap", flexWrapNewSyntax);
+  }
+
+  @Override
   public void _setFlex(Element el, double grow, String basis) {
     setStyleProperty(el,"WebkitBoxFlex", Double.toString(grow));
     setStyleProperty(el,"WebkitFlex", Double.toString(grow)+(basis == null ? "0%" : basis));

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/flex.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/flex.css
@@ -46,7 +46,7 @@
 
 @if user.agent ie10 {
   .mgwt-FlexPanel-flex {
-    -ms-flex: 1;
+    -ms-flex: 1 1;
   }
 }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/flex.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/flex/flex.css
@@ -17,6 +17,13 @@
   }
 }
 
+@if user.agent ie10 {
+  .mgwt-FlexPanel {
+    display: -ms-flexbox;
+    -ms-flex-direction: column;
+  }
+}
+
 .mgwt-FlexPanel {
   display: flex;
   flex-direction: column;
@@ -34,6 +41,12 @@
   .mgwt-FlexPanel-flex {
     -webkit-box-flex: 1; /* iOS < 7 && Android < 4.4*/
     -webkit-flex: 1;
+  }
+}
+
+@if user.agent ie10 {
+  .mgwt-FlexPanel-flex {
+    -ms-flex: 1;
   }
 }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/pull/pullpanel.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/pull/pullpanel.css
@@ -5,10 +5,30 @@
   @external mgwt-PullToRefresh-text, .mgwt-PullToRefresh-arrowFooter;
 }
 
+@if user.agent safari {
+  .mgwt-PullPanel {
+    -webkit-box-flex: 1; /* iOS < 7 && Android < 4.4*/
+    -webkit-flex: 1;
+  }
+}
+
+@if user.agent ie10 {
+  .mgwt-PullPanel {
+    -ms-flex: 1;
+  }
+}
+
+@if user.agent gecko1_8 {
+  .mgwt-PullPanel {
+    -moz-flex: 1;
+  }
+}
+
 .mgwt-PullPanel {
   flex: 1;
   overflow: hidden;
 }
+
 
 .mgwt-PullPanel-container{}
 .mgwt-PullPanel-main{}
@@ -38,6 +58,12 @@
 @if user.agent safari {
   .mgwt-PullToRefresh-arrow {
     -webkit-transform-origin: 12px 9px;
+  }
+}
+
+@if user.agent ie10 {
+  .mgwt-PullToRefresh-arrow {
+    transform-origin: 12px 9px;
   }
 }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/pull/pullpanel.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/pull/pullpanel.css
@@ -14,7 +14,7 @@
 
 @if user.agent ie10 {
   .mgwt-PullPanel {
-    -ms-flex: 1;
+    -ms-flex: 1 1;
   }
 }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/scroll/impl/ScrollPanelTouchImpl.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/scroll/impl/ScrollPanelTouchImpl.java
@@ -3,6 +3,7 @@ package com.googlecode.mgwt.ui.client.widget.panel.scroll.impl;
 import com.google.gwt.animation.client.AnimationScheduler;
 import com.google.gwt.animation.client.AnimationScheduler.AnimationCallback;
 import com.google.gwt.animation.client.AnimationScheduler.AnimationHandle;
+import com.google.gwt.core.client.Duration;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
@@ -23,12 +24,9 @@ import com.google.gwt.event.dom.client.TouchEndEvent;
 import com.google.gwt.event.dom.client.TouchEvent;
 import com.google.gwt.event.dom.client.TouchMoveEvent;
 import com.google.gwt.event.dom.client.TouchStartEvent;
-import com.google.gwt.event.logical.shared.ResizeEvent;
-import com.google.gwt.event.logical.shared.ResizeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Timer;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.Widget;
@@ -250,7 +248,7 @@ public class ScrollPanelTouchImpl extends ScrollPanelImpl {
   private int startY;
   private int pointX;
   private int pointY;
-  private long startTime;
+  private double startTime;
   private double touchesDist;
   private double lastScale;
   private boolean bounce;
@@ -673,7 +671,7 @@ public class ScrollPanelTouchImpl extends ScrollPanelImpl {
     int deltaY = touches.get(0).getPageY() - this.pointY;
     int newX = this.x + deltaX;
     int newY = this.y + deltaY;
-    long timeStamp = System.currentTimeMillis();
+    double timeStamp = Duration.currentTimeMillis();
 
     // fire onbeforescroll event
     fireEvent(new BeforeScrollMoveEvent(event));
@@ -774,7 +772,7 @@ public class ScrollPanelTouchImpl extends ScrollPanelImpl {
       return;
     }
 
-    long duration = System.currentTimeMillis() - this.startTime;
+    double duration = Duration.currentTimeMillis() - this.startTime;
     int newPosX = this.x;
     int newPosY = this.y;
     Momentum momentumX = Momentum.ZERO_MOMENTUM;
@@ -1081,7 +1079,7 @@ public class ScrollPanelTouchImpl extends ScrollPanelImpl {
       return;
     }
 
-    final long startTime = System.currentTimeMillis();
+    final double startTime = Duration.currentTimeMillis();
 
     final AnimationCallback animationCallback = new AnimationCallback() {
 
@@ -1128,7 +1126,7 @@ public class ScrollPanelTouchImpl extends ScrollPanelImpl {
 
   }
 
-  private Momentum momentum(int dist, long time, int maxDistUpper, int maxDistLower, int size) {
+  private Momentum momentum(int dist, double time, int maxDistUpper, int maxDistLower, int size) {
     double deceleration = 0.0006;
     double speed = ((double) (Math.abs(dist))) / time;
     double newDist = (speed * speed) / (2 * deceleration);

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/scroll/impl/ScrollPanelTouchImpl.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/scroll/impl/ScrollPanelTouchImpl.java
@@ -32,7 +32,6 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.Widget;
-
 import com.googlecode.mgwt.collection.shared.CollectionFactory;
 import com.googlecode.mgwt.collection.shared.LightArray;
 import com.googlecode.mgwt.collection.shared.LightArrayInt;
@@ -42,6 +41,7 @@ import com.googlecode.mgwt.dom.client.event.orientation.OrientationChangeEvent;
 import com.googlecode.mgwt.dom.client.event.orientation.OrientationChangeHandler;
 import com.googlecode.mgwt.dom.client.event.touch.TouchHandler;
 import com.googlecode.mgwt.ui.client.MGWT;
+import com.googlecode.mgwt.ui.client.TouchSupport;
 import com.googlecode.mgwt.ui.client.util.CssUtil;
 import com.googlecode.mgwt.ui.client.widget.panel.scroll.BeforeScrollEndEvent;
 import com.googlecode.mgwt.ui.client.widget.panel.scroll.BeforeScrollMoveEvent;
@@ -334,7 +334,7 @@ public class ScrollPanelTouchImpl extends ScrollPanelImpl {
 
     this.fixedScrollbar = MGWT.getOsDetection().isAndroid() && !MGWT.getOsDetection().isAndroid4_4_OrHigher();
     this.hideScrollBar = true;
-    this.fadeScrollBar = MGWT.getOsDetection().isIOs() && CssUtil.has3d();
+    this.fadeScrollBar = (MGWT.getOsDetection().isIOs() || MGWT.getOsDetection().isWindowsPhone()) && CssUtil.has3d();
 
     // array for scrollbars
     this.scrollBar = new boolean[2];
@@ -1596,7 +1596,7 @@ public class ScrollPanelTouchImpl extends ScrollPanelImpl {
     // clear old event handlers
     unbindStartEvent();
     unbindResizeEvent();
-    if (MGWT.getOsDetection().isDesktop()) {
+    if (TouchSupport.isTouchEventsEmulatedUsingMouseEvents()) {
       unbindMouseoutEvent();
       unbindMouseWheelEvent();
     }
@@ -1616,7 +1616,7 @@ public class ScrollPanelTouchImpl extends ScrollPanelImpl {
       if (isAttached()) {
         bindResizeEvent();
         bindStartEvent();
-        if (MGWT.getOsDetection().isDesktop()) {
+        if (TouchSupport.isTouchEventsEmulatedUsingMouseEvents()) {
           bindMouseoutEvent();
           bindMouseWheelEvent();
         }
@@ -1650,7 +1650,7 @@ public class ScrollPanelTouchImpl extends ScrollPanelImpl {
       // bind events
       bindResizeEvent();
       bindStartEvent();
-      if (MGWT.getOsDetection().isDesktop()) {
+      if (TouchSupport.isTouchEventsEmulatedUsingMouseEvents()) {
         bindMouseoutEvent();
         bindMouseWheelEvent();
       }

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/scroll/impl/ScrollPanelTouchImpl.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/scroll/impl/ScrollPanelTouchImpl.java
@@ -1775,30 +1775,16 @@ public class ScrollPanelTouchImpl extends ScrollPanelImpl {
 	 *
 	 */
   private void bindResizeEvent() {
-    if (!MGWT.getFormFactor().isDesktop()) {
-      orientationChangeRegistration = MGWT.addOrientationChangeHandler(new OrientationChangeHandler() {
+    orientationChangeRegistration = MGWT.addOrientationChangeHandler(new OrientationChangeHandler() {
 
-        @Override
-        public void onOrientationChanged(OrientationChangeEvent event) {
-          if (shouldHandleResize) {
-            resize();
-          }
-
+      @Override
+      public void onOrientationChanged(OrientationChangeEvent event) {
+        if (shouldHandleResize) {
+          resize();
         }
-      });
-    } else {
-      orientationChangeRegistration = Window.addResizeHandler(new ResizeHandler() {
-
-        @Override
-        public void onResize(ResizeEvent event) {
-          if (shouldHandleResize) {
-            resize();
-          }
-
-        }
-      });
-    }
-
+      }
+      
+    });
   }
 
   private void unbindResizeEvent() {

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/scroll/scrollpanel.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/panel/scroll/scrollpanel.css
@@ -21,6 +21,13 @@
   }
 }
 
+@if user.agent ie10 {
+  .mgwt-ScrollPanel-container {
+    transition-property: transform;
+    transition-timing-function: cubic-bezier(0, 0, 0.25, 1);
+  }
+}
+
 @if user.agent gecko1_8 {
   .mgwt-ScrollPanel-container {
     -moz-transition-property: literal('-moz-transform');
@@ -41,6 +48,14 @@
     -webkit-transition-duration: 300ms;
     -webkit-transition-delay: 0ms;
     -webkit-transition-property: opacity;
+  }
+}
+
+@if user.agent ie10 {
+  .mgwt-Scrollbar {
+    transition-duration: 300ms;
+    transition-delay: 0ms;
+    transition-property: opacity;
   }
 }
 
@@ -83,6 +98,18 @@
     -webkit-transition-timing-function:cubic-bezier(0.33,0.66,0.66,1);
     -webkit-transform: translate3d('0,0, 0');
     -webkit-transition-duration:0;
+  }
+}
+
+@if user.agent ie10 {
+  .mgwt-Scrollbar-Bar {
+    background-clip:padding-box;
+    box-sizing:border-box;
+    border-radius:3px;
+    transition-property:transform;
+    transition-timing-function:cubic-bezier(0.33,0.66,0.66,1);
+    transform: translate3d('0,0, 0');
+    transition-duration:0;
   }
 }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/progress/progressbar.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/progress/progressbar.css
@@ -28,6 +28,20 @@
   }
 }
 
+@if user.agent ie10 {
+  .mgwt-ProgressBar {
+    animation-duration: 9s;
+    animation-name: anmiateProgressBar;
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
+  }
+
+  @keyframes anmiateProgressBar {
+    0% { background-position-x:  0%; }
+    100% { background-position-x: 100%; } 
+  }
+}
+
 @if user.agent gecko1_8 {
   .mgwt-ProgressBar {
     -moz-animation-duration: 9s;
@@ -57,6 +71,15 @@
   }
 }
 
+@if user.agent ie10 {
+  .mgwt-ProgressBar {
+    background-size: 25px 15px;
+    box-shadow: 0 3px 3px rgba(0, 0, 0, 0.5);
+    box-sizing: border-box;
+    background-image: linear-gradient(60deg, rgba(255, 255, 255, 0) 25%, rgba(255, 255, 255, 0.7) 30%, rgba(255, 255, 255, 1) 30%, rgba(255, 255, 255, 1) 70%, rgba(255, 255, 255, 0.7) 70%, rgba(255, 255, 255, 0) 80%), linear-gradient(to bottom, rgba(0, 0, 0, .2) 5%, rgba(255, 255, 255, .8) 6%, rgba(255, 255, 255, .05) 40%, rgba(0, 0, 0, .05) 60%, rgba(0, 0, 0, .2) 90%, rgba(0, 0, 0, .5) 98%), linear-gradient(to bottom, transparent 20%, rgba(255, 255, 255, .5) 20%, rgba(255, 255, 255, .5) 50%, transparent 50%);
+  }
+}
+
 @if user.agent gecko1_8 {
   .mgwt-ProgressBar {
     background-size: 25px 15px;
@@ -66,7 +89,7 @@
   }
 }
 
-@if user.agent ie9 ie10 {
+@if user.agent ie9 {
   .mgwt-ProgressBar {
     -ms-background-size: 25px 15px;
     -ms-box-shadow: 0 3px 3px rgba(0, 0, 0, 0.5);

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/progress/progressindicator.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/progress/progressindicator.css
@@ -21,6 +21,7 @@
 	-webkit-animation-iteration-count: infinite;
 	-webkit-animation-timing-function: linear;
 	-webkit-animation-name: progressIndicatorAnimation;
+	-webkit-transform: scale(0.25);
   }
 
   .mgwt-ProgressIndicator > span:nth-child\(2\) {
@@ -48,12 +49,47 @@
   }
 }
 
+@if user.agent ie10 {
+  .mgwt-ProgressIndicator > span {
+	animation-duration: 1s;
+	animation-iteration-count: infinite;
+	animation-timing-function: linear;
+	animation-name: progressIndicatorAnimation;
+	transform: scale(0.25);
+  }
+
+  .mgwt-ProgressIndicator > span:nth-child\(2\) {
+    animation-delay: 0.33s;
+  }
+  .mgwt-ProgressIndicator > span:nth-child\(3\) {
+    animation-delay: 0.66s;
+  }
+
+  @keyframes progressIndicatorAnimation {
+    0% {
+      transform: scale(0.25);
+      background-color: #1e7dc8;
+    }
+    16% {
+      transform: scale(1.0);
+      background-color: #1e7dc8;
+    }
+    33% {
+      transform: scale(0.25);
+    }
+    100% {
+      transform: scale(0.25);
+    }
+  }
+}
+
 @if user.agent gecko1_8 {
   .mgwt-ProgressIndicator > span {
 	-moz-animation-duration: 1s;
 	-moz-animation-iteration-count: infinite;
 	-moz-animation-timing-function: linear;
 	-moz-animation-name: progressIndicatorAnimation;
+    -moz-transform: scale(0.25);
   }
 
   .mgwt-ProgressIndicator > span:nth-child\(2\) {

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/progress/progressspinner.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/progress/progressspinner.css
@@ -20,63 +20,62 @@
   border-radius: 2px;
 }
 
-.mgwt-ProgressSpinner > span:nth-child\(1\) {
-  -webkit-transform: translate3d(0, -10px, 0);
-}
-
-.mgwt-ProgressSpinner > span:nth-child\(2\) {
-  -webkit-transform: translate3d(5px, -8.66px, 0) rotate(30deg);
-}
-
-.mgwt-ProgressSpinner > span:nth-child\(3\) {
-  -webkit-transform: translate3d(8.66px, -5px, 0) rotate(60deg);
-}
-
-.mgwt-ProgressSpinner > span:nth-child\(4\) {
-  -webkit-transform: translate3d(10px, 0, 0) rotate(90deg);
-}
-
-.mgwt-ProgressSpinner > span:nth-child\(5\) {
-  -webkit-transform: translate3d(8.66px, 5px, 0) rotate(120deg);
-}
-
-.mgwt-ProgressSpinner > span:nth-child\(6\) {
-  -webkit-transform: translate3d(5px, 8.66px, 0) rotate(150deg);
-}
-
-.mgwt-ProgressSpinner > span:nth-child\(7\) {
-  -webkit-transform: translate3d(0px, 10px, 0);
-}
-
-.mgwt-ProgressSpinner > span:nth-child\(8\) {
-  -webkit-transform: translate3d(-5px, 8.66px, 0) rotate(210deg);
-}
-
-.mgwt-ProgressSpinner > span:nth-child\(9\) {
-  -webkit-transform: translate3d(-8.66px, 5px, 0) rotate(240deg);
-}
-
-.mgwt-ProgressSpinner > span:nth-child\(10\) {
-  -webkit-transform: translate3d(-10px, 0, 0) rotate(90deg);;
-}
-
-.mgwt-ProgressSpinner > span:nth-child\(11\) {
-  -webkit-transform: translate3d(-8.66px, -5px, 0) rotate(300deg);
-}
-
-.mgwt-ProgressSpinner > span:nth-child\(12\) {
-  -webkit-transform: translate3d(-5px, -8.66px, 0) rotate(330deg);
-}
-
-
-.mgwt-ProgressSpinner > span {
-  -webkit-animation-iteration-count: infinite;
-  -webkit-animation-timing-function: linear;
-  -webkit-animation-duration: ANIMATION_DURATION;
-  -webkit-animation-name: animationProgressSpinner;
-}
-
 @if user.agent safari {
+	.mgwt-ProgressSpinner > span:nth-child\(1\) {
+	  -webkit-transform: translate3d(0, -10px, 0);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(2\) {
+	  -webkit-transform: translate3d(5px, -8.66px, 0) rotate(30deg);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(3\) {
+	  -webkit-transform: translate3d(8.66px, -5px, 0) rotate(60deg);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(4\) {
+	  -webkit-transform: translate3d(10px, 0, 0) rotate(90deg);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(5\) {
+	  -webkit-transform: translate3d(8.66px, 5px, 0) rotate(120deg);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(6\) {
+	  -webkit-transform: translate3d(5px, 8.66px, 0) rotate(150deg);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(7\) {
+	  -webkit-transform: translate3d(0px, 10px, 0);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(8\) {
+	  -webkit-transform: translate3d(-5px, 8.66px, 0) rotate(210deg);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(9\) {
+	  -webkit-transform: translate3d(-8.66px, 5px, 0) rotate(240deg);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(10\) {
+	  -webkit-transform: translate3d(-10px, 0, 0) rotate(90deg);;
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(11\) {
+	  -webkit-transform: translate3d(-8.66px, -5px, 0) rotate(300deg);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(12\) {
+	  -webkit-transform: translate3d(-5px, -8.66px, 0) rotate(330deg);
+	}
+	
+	.mgwt-ProgressSpinner > span {
+	  -webkit-animation-iteration-count: infinite;
+	  -webkit-animation-timing-function: linear;
+	  -webkit-animation-duration: ANIMATION_DURATION;
+	  -webkit-animation-name: animationProgressSpinner;
+	}
+
   @-webkit-keyframes animationProgressSpinner {
     0% { background: transparent;}
     8% { background:  #464F5D;}
@@ -92,9 +91,7 @@
     92% { background:  #DCDCE4;}
     100% { background: transparent;}	
   }
-}
 
-@if user.agent safari {
   .mgwt-ProgressSpinner > span:nth-child\(2\) {
     -webkit-animation-delay: 0.08s;
   }
@@ -129,3 +126,112 @@
     -webkit-animation-delay: 0.92s;
   }
 }
+
+@if user.agent ie10 {
+	.mgwt-ProgressSpinner > span:nth-child\(1\) {
+	  transform: translate3d(0, -10px, 0);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(2\) {
+	  transform: translate3d(5px, -8.66px, 0) rotate(30deg);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(3\) {
+	  transform: translate3d(8.66px, -5px, 0) rotate(60deg);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(4\) {
+	  transform: translate3d(10px, 0, 0) rotate(90deg);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(5\) {
+	  transform: translate3d(8.66px, 5px, 0) rotate(120deg);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(6\) {
+	  transform: translate3d(5px, 8.66px, 0) rotate(150deg);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(7\) {
+	  transform: translate3d(0px, 10px, 0);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(8\) {
+	  transform: translate3d(-5px, 8.66px, 0) rotate(210deg);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(9\) {
+	  transform: translate3d(-8.66px, 5px, 0) rotate(240deg);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(10\) {
+	  transform: translate3d(-10px, 0, 0) rotate(90deg);;
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(11\) {
+	  transform: translate3d(-8.66px, -5px, 0) rotate(300deg);
+	}
+	
+	.mgwt-ProgressSpinner > span:nth-child\(12\) {
+	  transform: translate3d(-5px, -8.66px, 0) rotate(330deg);
+	}
+	
+	.mgwt-ProgressSpinner > span {
+	  animation-iteration-count: infinite;
+	  animation-timing-function: linear;
+	  animation-duration: ANIMATION_DURATION;
+	  animation-name: animationProgressSpinner;
+	}
+
+  @keyframes animationProgressSpinner {
+    0% { background: transparent;}
+    8% { background:  #464F5D;}
+    17% { background:  #59606C;}
+    25% { background:  #656C78;}
+    33% { background:  #747B85;}
+    41% { background:  #828791;}
+    50% { background:  #8D929B;}
+    58% { background:  #A0A4AD;}
+    67% { background:  #ADB0BA;}
+    75% { background:  #BCBEC7;}
+    83% { background:  #CDCED5;}
+    92% { background:  #DCDCE4;}
+    100% { background: transparent;}	
+  }
+
+  .mgwt-ProgressSpinner > span:nth-child\(2\) {
+    animation-delay: 0.08s;
+  }
+  .mgwt-ProgressSpinner > span:nth-child\(3\) {
+    animation-delay: 0.17s;
+  }
+  .mgwt-ProgressSpinner > span:nth-child\(4\) {
+    animation-delay: 0.25s;
+  }
+  .mgwt-ProgressSpinner > span:nth-child\(5\) {
+    animation-delay: 0.33s;
+  }
+  .mgwt-ProgressSpinner > span:nth-child\(6\) {
+    animation-delay: 0.41s;
+  }
+  .mgwt-ProgressSpinner > span:nth-child\(7\) {
+    animation-delay: 0.5s;
+  }
+  .mgwt-ProgressSpinner > span:nth-child\(8\) {
+    animation-delay: 0.58s;
+  }
+  .mgwt-ProgressSpinner > span:nth-child\(9\) {
+    animation-delay: 0.67s;
+  }
+  .mgwt-ProgressSpinner > span:nth-child\(10\) {
+    animation-delay: 0.75s;
+  }
+  .mgwt-ProgressSpinner > span:nth-child\(11\) {
+    animation-delay: 0.83s;
+  }
+  .mgwt-ProgressSpinner > span:nth-child\(12\) {
+    animation-delay: 0.92s;
+  }
+}
+
+

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/tabbar/tabbar-button.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/tabbar/tabbar-button.css
@@ -26,7 +26,7 @@
   .mgwt-TabBar-Button {
     display: -ms-flexbox;
 	-ms-flex-direction: column;
-    -ms-flex: 1;
+    -ms-flex: 1 1;
   }
 }
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/tabbar/tabbar-button.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/tabbar/tabbar-button.css
@@ -12,22 +12,37 @@
 
 @if user.agent safari {
   .mgwt-TabBar-Button {
+    display: -webkit-box; /* iOS < 7 && Android < 4.4*/
+    display: -webkit-flex;
+    -webkit-box-orient: vertical; /* iOS < 7 && Android < 4.4*/
+    -webkit-flex-direction: column;
+    -webkit-box-flex: 1; /* iOS < 7 && Android < 4.4*/
+    -webkit-flex: 1;
     -webkit-appearance: none;
-    -webkit-box-flex: 1;
+  }
+}
+
+@if user.agent ie10 {
+  .mgwt-TabBar-Button {
+    display: -ms-flexbox;
+	-ms-flex-direction: column;
+    -ms-flex: 1;
   }
 }
 
 @if user.agent gecko1_8 {
   .mgwt-TabBar-Button {
-    -moz-appearance: none;
+    display: -moz-box;
+	-moz-flex-direction: column;
     -moz-box-flex: 1;
+    -moz-appearance: none;
   }
 }
 
 .mgwt-TabBar-Button {
   display: flex;
-  flex: 1;
   flex-direction: column;
+  flex: 1;
   min-width: 60px;
   background-color: transparent;
   height: 39px;

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/tabbar/tabbar.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/tabbar/tabbar.css
@@ -16,7 +16,7 @@
 @if user.agent ie10 {
   .mgwt-TabPanel {
     display: -ms-flexbox;
-    -ms-flex: 1;
+    -ms-flex: 1 1;
     -ms-flex-direction: column;
   }
 }
@@ -49,7 +49,7 @@
 @if user.agent ie10 {
   .mgwt-TabPanel-container {
     display: -ms-flexbox;
-    -ms-flex: 1;
+    -ms-flex: 1 1;
     -ms-flex-direction: column;
   }
 }

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/tabbar/tabbar.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/tabbar/tabbar.css
@@ -5,14 +5,25 @@
 @if user.agent safari {
   .mgwt-TabPanel {
     display: -webkit-box;
+    display: -webkit-flex;
     -webkit-box-flex: 1;
+    -webkit-flex: 1;
     -webkit-box-orient: vertical;
+    -webkit-flex-direction: column;
+  }
+}
+
+@if user.agent ie10 {
+  .mgwt-TabPanel {
+    display: -ms-flexbox;
+    -ms-flex: 1;
+    -ms-flex-direction: column;
   }
 }
 
 @if user.agent gecko1_8 {
   .mgwt-TabPanel {
-    display: -webkit-box;
+    display: -moz-box;
     -moz-box-flex: 1;
     -moz-box-orient: vertical;
   }
@@ -27,14 +38,25 @@
 @if user.agent safari {
   .mgwt-TabPanel-container {
     display: -webkit-box;
+    display: -webkit-flex;
     -webkit-box-flex: 1;
+    -webkit-flex: 1;
     -webkit-box-orient: vertical;
+    -webkit-flex-direction: column;
+  }
+}
+
+@if user.agent ie10 {
+  .mgwt-TabPanel-container {
+    display: -ms-flexbox;
+    -ms-flex: 1;
+    -ms-flex-direction: column;
   }
 }
 
 @if user.agent gecko1_8 {
   .mgwt-TabPanel-container {
-    display: -webkit-box;
+    display: -moz-box;
     -moz-box-flex: 1;
     -moz-box-orient: vertical;
   }
@@ -44,14 +66,25 @@
   overflow: hidden;
   display: flex;
   flex:1;
+  flex-direction: column;
 }
 
 @if user.agent safari {
   .mgwt-TabBar {
     display: -webkit-box;
+    display: -webkit-flex;
     -webkit-box-orient: horizontal;
+    -webkit-flex-direction: row;
   }
 }
+
+@if user.agent ie10 {
+  .mgwt-TabBar {
+    display: -ms-flexbox;
+    -ms-flex-direction: row;
+  }
+}
+
 @if user.agent gecko1_8 {
   .mgwt-TabBar {
     display: -moz-box;

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/touch/TouchPanel.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/touch/TouchPanel.java
@@ -23,8 +23,6 @@ import com.google.gwt.event.dom.client.TouchMoveHandler;
 import com.google.gwt.event.dom.client.TouchStartHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.FlowPanel;
-
-import com.googlecode.mgwt.dom.client.event.mouse.HandlerRegistrationCollection;
 import com.googlecode.mgwt.dom.client.event.tap.HasTapHandlers;
 import com.googlecode.mgwt.dom.client.event.tap.TapEvent;
 import com.googlecode.mgwt.dom.client.event.tap.TapHandler;
@@ -83,13 +81,7 @@ public class TouchPanel extends FlowPanel implements HasTouchHandlers, HasTapHan
 
 	@Override
 	public HandlerRegistration addTouchHandler(TouchHandler handler) {
-		HandlerRegistrationCollection handlerRegistrationCollection = new HandlerRegistrationCollection();
-
-		handlerRegistrationCollection.addHandlerRegistration(addTouchCancelHandler(handler));
-		handlerRegistrationCollection.addHandlerRegistration(addTouchStartHandler(handler));
-		handlerRegistrationCollection.addHandlerRegistration(addTouchEndHandler(handler));
-		handlerRegistrationCollection.addHandlerRegistration(addTouchMoveHandler(handler));
-		return handlerRegistrationCollection;
+	  return impl.addTouchHandler(this, handler);
 	}
 
 	@Override

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/touch/TouchWidget.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/touch/TouchWidget.java
@@ -83,13 +83,14 @@ public abstract class TouchWidget extends Widget implements HasTouchHandlers, Ha
 
 	@Override
 	public HandlerRegistration addTouchHandler(TouchHandler handler) {
-		HandlerRegistrationCollection handlerRegistrationCollection = new HandlerRegistrationCollection();
-
-		handlerRegistrationCollection.addHandlerRegistration(addTouchCancelHandler(handler));
-		handlerRegistrationCollection.addHandlerRegistration(addTouchStartHandler(handler));
-		handlerRegistrationCollection.addHandlerRegistration(addTouchEndHandler(handler));
-		handlerRegistrationCollection.addHandlerRegistration(addTouchMoveHandler(handler));
-		return handlerRegistrationCollection;
+	    return impl.addTouchHandler(this, handler);
+//		HandlerRegistrationCollection handlerRegistrationCollection = new HandlerRegistrationCollection();
+//
+//		handlerRegistrationCollection.addHandlerRegistration(addTouchCancelHandler(handler));
+//		handlerRegistrationCollection.addHandlerRegistration(addTouchStartHandler(handler));
+//		handlerRegistrationCollection.addHandlerRegistration(addTouchEndHandler(handler));
+//		handlerRegistrationCollection.addHandlerRegistration(addTouchMoveHandler(handler));
+//		return handlerRegistrationCollection;
 	}
 
   @Override

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/touch/TouchWidget.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/touch/TouchWidget.java
@@ -22,8 +22,6 @@ import com.google.gwt.event.dom.client.TouchMoveHandler;
 import com.google.gwt.event.dom.client.TouchStartHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Widget;
-
-import com.googlecode.mgwt.dom.client.event.mouse.HandlerRegistrationCollection;
 import com.googlecode.mgwt.dom.client.event.tap.HasTapHandlers;
 import com.googlecode.mgwt.dom.client.event.tap.TapEvent;
 import com.googlecode.mgwt.dom.client.event.tap.TapHandler;

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/touch/TouchWidgetImpl.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/touch/TouchWidgetImpl.java
@@ -15,26 +15,13 @@
  */
 package com.googlecode.mgwt.ui.client.widget.touch;
 
-import com.google.gwt.event.dom.client.MouseDownEvent;
-import com.google.gwt.event.dom.client.MouseMoveEvent;
-import com.google.gwt.event.dom.client.MouseUpEvent;
-import com.google.gwt.event.dom.client.TouchCancelEvent;
 import com.google.gwt.event.dom.client.TouchCancelHandler;
-import com.google.gwt.event.dom.client.TouchEndEvent;
 import com.google.gwt.event.dom.client.TouchEndHandler;
-import com.google.gwt.event.dom.client.TouchMoveEvent;
 import com.google.gwt.event.dom.client.TouchMoveHandler;
-import com.google.gwt.event.dom.client.TouchStartEvent;
 import com.google.gwt.event.dom.client.TouchStartHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Widget;
-
-import com.googlecode.mgwt.dom.client.event.mouse.HandlerRegistrationCollection;
-import com.googlecode.mgwt.dom.client.event.mouse.TouchEndToMouseUpHandler;
-import com.googlecode.mgwt.dom.client.event.mouse.TouchMoveToMouseMoveHandler;
-import com.googlecode.mgwt.dom.client.event.mouse.TouchStartToMouseDownHandler;
 import com.googlecode.mgwt.dom.client.event.touch.TouchHandler;
-import com.googlecode.mgwt.ui.client.util.NoopHandlerRegistration;
 
 /**
  * The touch widget interface is used to abstract implementation details for
@@ -42,109 +29,7 @@ import com.googlecode.mgwt.ui.client.util.NoopHandlerRegistration;
  *
  * @author Daniel Kurka
  */
-public abstract class TouchWidgetImpl {
-
-  private static class TouchWidgetMobileImpl extends TouchWidgetImpl {
-
-    @Override
-    public HandlerRegistration addTouchStartHandler(Widget w, TouchStartHandler handler) {
-      return w.addDomHandler(handler, TouchStartEvent.getType());
-    }
-
-    @Override
-    public HandlerRegistration addTouchMoveHandler(Widget w, TouchMoveHandler handler) {
-      return w.addDomHandler(handler, TouchMoveEvent.getType());
-    }
-
-    @Override
-    public HandlerRegistration addTouchCancelHandler(Widget w, TouchCancelHandler handler) {
-      return w.addDomHandler(handler, TouchCancelEvent.getType());
-    }
-
-    @Override
-    public HandlerRegistration addTouchEndHandler(Widget w, TouchEndHandler handler) {
-      return w.addDomHandler(handler, TouchEndEvent.getType());
-    }
-
-    @Override
-    public HandlerRegistration addTouchHandler(Widget w, TouchHandler handler) {
-      HandlerRegistrationCollection hrc = new HandlerRegistrationCollection();
-      hrc.addHandlerRegistration(addTouchStartHandler(w, handler));
-      hrc.addHandlerRegistration(addTouchMoveHandler(w, handler));
-      hrc.addHandlerRegistration(addTouchEndHandler(w, handler));
-      hrc.addHandlerRegistration(addTouchCancelHandler(w, handler));
-      return hrc;
-    }
-  }
-
-  // Used with deffered binding
-  @SuppressWarnings("unused")
-  private static class TouchWidgetRuntimeImpl extends TouchWidgetImpl {
-    private static boolean hasTouchSupport;
-    private static TouchWidgetImpl delegate;
-
-    static {
-      hasTouchSupport = hasTouch();
-      if (hasTouchSupport) {
-        delegate = new TouchWidgetMobileImpl();
-      }
-    }
-
-    private static native boolean hasTouch() /*-{
-      return 'ontouchstart' in $doc.documentElement;
-    }-*/;
-
-
-    @Override
-    public HandlerRegistration addTouchStartHandler(Widget w, TouchStartHandler handler) {
-      if (hasTouchSupport) {
-        return delegate.addTouchStartHandler(w, handler);
-      }
-      return w.addDomHandler(new TouchStartToMouseDownHandler(handler), MouseDownEvent.getType());
-    }
-
-    @Override
-    public HandlerRegistration addTouchMoveHandler(Widget w, TouchMoveHandler handler) {
-      if (hasTouchSupport) {
-        return delegate.addTouchMoveHandler(w, handler);
-      }
-      TouchMoveToMouseMoveHandler touchMoveToMouseMoveHandler = new TouchMoveToMouseMoveHandler(handler);
-      HandlerRegistrationCollection handlerRegistrationCollection = new HandlerRegistrationCollection();
-      handlerRegistrationCollection.addHandlerRegistration(w.addDomHandler(touchMoveToMouseMoveHandler, MouseDownEvent.getType()));
-      handlerRegistrationCollection.addHandlerRegistration(w.addDomHandler(touchMoveToMouseMoveHandler, MouseUpEvent.getType()));
-      handlerRegistrationCollection.addHandlerRegistration(w.addDomHandler(touchMoveToMouseMoveHandler, MouseMoveEvent.getType()));
-      return handlerRegistrationCollection;
-    }
-
-    @Override
-    public HandlerRegistration addTouchCancelHandler(Widget w, TouchCancelHandler handler) {
-      if (hasTouchSupport) {
-        return delegate.addTouchCancelHandler(w, handler);
-      }
-      return new NoopHandlerRegistration();
-    }
-
-    @Override
-    public HandlerRegistration addTouchEndHandler(Widget w, TouchEndHandler handler) {
-      if (hasTouchSupport) {
-        return delegate.addTouchEndHandler(w, handler);
-      }
-      return w.addDomHandler(new TouchEndToMouseUpHandler(handler), MouseUpEvent.getType());
-    }
-
-    @Override
-    public HandlerRegistration addTouchHandler(Widget w, TouchHandler handler) {
-      if (hasTouchSupport) {
-        return delegate.addTouchHandler(w, handler);
-      }
-      HandlerRegistrationCollection hrc = new HandlerRegistrationCollection();
-      hrc.addHandlerRegistration(addTouchStartHandler(w, handler));
-      hrc.addHandlerRegistration(addTouchMoveHandler(w, handler));
-      hrc.addHandlerRegistration(addTouchEndHandler(w, handler));
-      hrc.addHandlerRegistration(addTouchCancelHandler(w, handler));
-      return hrc;
-    }
-  }
+public interface TouchWidgetImpl {
 
 	/**
 	 * Add a touch start handler to a widget

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/touch/TouchWidgetPointerImpl.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/touch/TouchWidgetPointerImpl.java
@@ -1,0 +1,57 @@
+package com.googlecode.mgwt.ui.client.widget.touch;
+
+import com.google.gwt.event.dom.client.TouchCancelHandler;
+import com.google.gwt.event.dom.client.TouchEndHandler;
+import com.google.gwt.event.dom.client.TouchMoveHandler;
+import com.google.gwt.event.dom.client.TouchStartHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.ui.Widget;
+import com.googlecode.mgwt.dom.client.event.mouse.HandlerRegistrationCollection;
+import com.googlecode.mgwt.dom.client.event.pointer.MsPointerCancelEvent;
+import com.googlecode.mgwt.dom.client.event.pointer.MsPointerDownEvent;
+import com.googlecode.mgwt.dom.client.event.pointer.MsPointerMoveEvent;
+import com.googlecode.mgwt.dom.client.event.pointer.MsPointerUpEvent;
+import com.googlecode.mgwt.dom.client.event.pointer.TouchCancelToMsPointerCancelHandler;
+import com.googlecode.mgwt.dom.client.event.pointer.TouchEndToMsPointerUpHandler;
+import com.googlecode.mgwt.dom.client.event.pointer.TouchMoveToMsPointerMoveHandler;
+import com.googlecode.mgwt.dom.client.event.pointer.TouchStartToMsPointerDownHandler;
+import com.googlecode.mgwt.dom.client.event.touch.TouchHandler;
+
+public class TouchWidgetPointerImpl implements TouchWidgetImpl
+{
+  @Override
+  public HandlerRegistration addTouchStartHandler(Widget w, TouchStartHandler handler) {
+    return w.addBitlessDomHandler(new TouchStartToMsPointerDownHandler(handler), MsPointerDownEvent.getType());
+  }
+
+  @Override
+  public HandlerRegistration addTouchMoveHandler(Widget w, TouchMoveHandler handler) {
+    TouchMoveToMsPointerMoveHandler touchMoveToMsPointerMoveHandler = new TouchMoveToMsPointerMoveHandler(handler);
+    HandlerRegistrationCollection handlerRegistrationCollection = new HandlerRegistrationCollection();
+    handlerRegistrationCollection.addHandlerRegistration(w.addBitlessDomHandler(touchMoveToMsPointerMoveHandler, MsPointerDownEvent.getType()));
+    handlerRegistrationCollection.addHandlerRegistration(w.addBitlessDomHandler(touchMoveToMsPointerMoveHandler, MsPointerUpEvent.getType()));
+    handlerRegistrationCollection.addHandlerRegistration(w.addBitlessDomHandler(touchMoveToMsPointerMoveHandler, MsPointerMoveEvent.getType()));
+    return handlerRegistrationCollection;
+  }
+
+  @Override
+  public HandlerRegistration addTouchCancelHandler(Widget w, TouchCancelHandler handler) {
+    return w.addBitlessDomHandler(new TouchCancelToMsPointerCancelHandler(handler), MsPointerCancelEvent.getType());
+  }
+
+  @Override
+  public HandlerRegistration addTouchEndHandler(Widget w, TouchEndHandler handler) {
+    return w.addBitlessDomHandler(new TouchEndToMsPointerUpHandler(handler), MsPointerUpEvent.getType());
+  }
+
+  @Override
+  public HandlerRegistration addTouchHandler(Widget w, TouchHandler handler) {
+    HandlerRegistrationCollection hrc = new HandlerRegistrationCollection();
+    hrc.addHandlerRegistration(addTouchStartHandler(w, handler));
+    hrc.addHandlerRegistration(addTouchMoveHandler(w, handler));
+    hrc.addHandlerRegistration(addTouchEndHandler(w, handler));
+    hrc.addHandlerRegistration(addTouchCancelHandler(w, handler));
+    return hrc;
+  }
+
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/touch/TouchWidgetStandardImpl.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/touch/TouchWidgetStandardImpl.java
@@ -1,0 +1,86 @@
+package com.googlecode.mgwt.ui.client.widget.touch;
+
+import com.google.gwt.event.dom.client.MouseDownEvent;
+import com.google.gwt.event.dom.client.MouseMoveEvent;
+import com.google.gwt.event.dom.client.MouseUpEvent;
+import com.google.gwt.event.dom.client.TouchCancelHandler;
+import com.google.gwt.event.dom.client.TouchEndHandler;
+import com.google.gwt.event.dom.client.TouchMoveHandler;
+import com.google.gwt.event.dom.client.TouchStartHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.ui.Widget;
+import com.googlecode.mgwt.dom.client.event.mouse.HandlerRegistrationCollection;
+import com.googlecode.mgwt.dom.client.event.mouse.TouchEndToMouseUpHandler;
+import com.googlecode.mgwt.dom.client.event.mouse.TouchMoveToMouseMoveHandler;
+import com.googlecode.mgwt.dom.client.event.mouse.TouchStartToMouseDownHandler;
+import com.googlecode.mgwt.dom.client.event.touch.TouchHandler;
+import com.googlecode.mgwt.ui.client.util.NoopHandlerRegistration;
+
+public class TouchWidgetStandardImpl implements TouchWidgetImpl
+{
+  private static boolean hasTouchSupport;
+  private static TouchWidgetImpl delegate;
+
+  static {
+    hasTouchSupport = hasTouch();
+    if (hasTouchSupport) {
+      delegate = new TouchWidgetTouchImpl();
+    }
+  }
+
+  private static native boolean hasTouch() /*-{
+    return 'ontouchstart' in $doc.documentElement;
+  }-*/;
+
+
+  @Override
+  public HandlerRegistration addTouchStartHandler(Widget w, TouchStartHandler handler) {
+    if (hasTouchSupport) {
+      return delegate.addTouchStartHandler(w, handler);
+    }
+    return w.addDomHandler(new TouchStartToMouseDownHandler(handler), MouseDownEvent.getType());
+  }
+
+  @Override
+  public HandlerRegistration addTouchMoveHandler(Widget w, TouchMoveHandler handler) {
+    if (hasTouchSupport) {
+      return delegate.addTouchMoveHandler(w, handler);
+    }
+    TouchMoveToMouseMoveHandler touchMoveToMouseMoveHandler = new TouchMoveToMouseMoveHandler(handler);
+    HandlerRegistrationCollection handlerRegistrationCollection = new HandlerRegistrationCollection();
+    handlerRegistrationCollection.addHandlerRegistration(w.addDomHandler(touchMoveToMouseMoveHandler, MouseDownEvent.getType()));
+    handlerRegistrationCollection.addHandlerRegistration(w.addDomHandler(touchMoveToMouseMoveHandler, MouseUpEvent.getType()));
+    handlerRegistrationCollection.addHandlerRegistration(w.addDomHandler(touchMoveToMouseMoveHandler, MouseMoveEvent.getType()));
+    return handlerRegistrationCollection;
+  }
+
+  @Override
+  public HandlerRegistration addTouchCancelHandler(Widget w, TouchCancelHandler handler) {
+    if (hasTouchSupport) {
+      return delegate.addTouchCancelHandler(w, handler);
+    }
+    return new NoopHandlerRegistration();
+  }
+
+  @Override
+  public HandlerRegistration addTouchEndHandler(Widget w, TouchEndHandler handler) {
+    if (hasTouchSupport) {
+      return delegate.addTouchEndHandler(w, handler);
+    }
+    return w.addDomHandler(new TouchEndToMouseUpHandler(handler), MouseUpEvent.getType());
+  }
+
+  @Override
+  public HandlerRegistration addTouchHandler(Widget w, TouchHandler handler) {
+    if (hasTouchSupport) {
+      return delegate.addTouchHandler(w, handler);
+    }
+    HandlerRegistrationCollection hrc = new HandlerRegistrationCollection();
+    hrc.addHandlerRegistration(addTouchStartHandler(w, handler));
+    hrc.addHandlerRegistration(addTouchMoveHandler(w, handler));
+    hrc.addHandlerRegistration(addTouchEndHandler(w, handler));
+    hrc.addHandlerRegistration(addTouchCancelHandler(w, handler));
+    return hrc;
+  }
+
+}

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/touch/TouchWidgetTouchImpl.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/touch/TouchWidgetTouchImpl.java
@@ -1,0 +1,47 @@
+package com.googlecode.mgwt.ui.client.widget.touch;
+
+import com.google.gwt.event.dom.client.TouchCancelEvent;
+import com.google.gwt.event.dom.client.TouchCancelHandler;
+import com.google.gwt.event.dom.client.TouchEndEvent;
+import com.google.gwt.event.dom.client.TouchEndHandler;
+import com.google.gwt.event.dom.client.TouchMoveEvent;
+import com.google.gwt.event.dom.client.TouchMoveHandler;
+import com.google.gwt.event.dom.client.TouchStartEvent;
+import com.google.gwt.event.dom.client.TouchStartHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.ui.Widget;
+import com.googlecode.mgwt.dom.client.event.mouse.HandlerRegistrationCollection;
+import com.googlecode.mgwt.dom.client.event.touch.TouchHandler;
+
+public class TouchWidgetTouchImpl implements TouchWidgetImpl
+{
+  @Override
+  public HandlerRegistration addTouchStartHandler(Widget w, TouchStartHandler handler) {
+    return w.addDomHandler(handler, TouchStartEvent.getType());
+  }
+
+  @Override
+  public HandlerRegistration addTouchMoveHandler(Widget w, TouchMoveHandler handler) {
+    return w.addDomHandler(handler, TouchMoveEvent.getType());
+  }
+
+  @Override
+  public HandlerRegistration addTouchCancelHandler(Widget w, TouchCancelHandler handler) {
+    return w.addDomHandler(handler, TouchCancelEvent.getType());
+  }
+
+  @Override
+  public HandlerRegistration addTouchEndHandler(Widget w, TouchEndHandler handler) {
+    return w.addDomHandler(handler, TouchEndEvent.getType());
+  }
+
+  @Override
+  public HandlerRegistration addTouchHandler(Widget w, TouchHandler handler) {
+    HandlerRegistrationCollection hrc = new HandlerRegistrationCollection();
+    hrc.addHandlerRegistration(addTouchStartHandler(w, handler));
+    hrc.addHandlerRegistration(addTouchMoveHandler(w, handler));
+    hrc.addHandlerRegistration(addTouchEndHandler(w, handler));
+    hrc.addHandlerRegistration(addTouchCancelHandler(w, handler));
+    return hrc;
+  }
+}

--- a/src/test/java/com/googlecode/mgwt/image/client/ImageConverterGwtTestCase.java
+++ b/src/test/java/com/googlecode/mgwt/image/client/ImageConverterGwtTestCase.java
@@ -40,9 +40,29 @@ public class ImageConverterGwtTestCase extends GWTTestCase {
   @DoNotRunWith(Platform.HtmlUnitUnknown)
   public void testConvert_withKnownImage() {
     ImageConverter imageConverter = new ImageConverter();
-    ImageResource convertedResource = imageConverter.convert(
-        ImageConverterTestBundle.INSTANCE.knownImage(), "#0000F1");
+    ImageResource convertedResource = null;
+    
+    ImageConverterCallback callback = new ImageConverterCallback()
+    {
+      public ImageResource convertedResource = null;
+      
+      @Override
+      public void onFailure(Throwable caught)
+      {
+      }
 
+      @Override
+      public void onSuccess(ImageResource convertedResource)
+      {
+        this.convertedResource = convertedResource;
+      }
+      
+    };
+
+    imageConverter.convert(ImageConverterTestBundle.INSTANCE.knownImage(), "#0000F1", callback);
+    
+    delayTestFinish(200);
+    
     /*
      * Dirty hack to test, should be improved.
      */

--- a/src/test/java/com/googlecode/mgwt/ui/client/widget/input/search/MSearchBoxGwtTest.java
+++ b/src/test/java/com/googlecode/mgwt/ui/client/widget/input/search/MSearchBoxGwtTest.java
@@ -93,7 +93,7 @@ public class MSearchBoxGwtTest extends GWTTestCase {
         assertEquals(4, valueChangeEventCount);
         assertEquals(0, clearCount);
 
-        mSearchBox.clearButton.fireEvent(new TapEvent(this, null, 0, 0));
+        mSearchBox.clearButton.fireEvent(new TapEvent(this, null, null));
 
         assertEquals("", mSearchBox.getValue());
         assertEquals(2, submitCount);


### PR DESCRIPTION
Hello Daniel,

I've added wp8 support and so desktop ie10/11 as well as mobile ie10/11 to mgwt 2.0

I've tested against the latest showcase and it all seems to work well. The swap animation is not great but I think this is due to ie10 not supporting preserve-3d.

Pointer events are by default set to be captured by the target element that receives the pointer down event. This is done using the pointer capture approach and not the built in GWT event capture method. This means we have the same behaviour as IOS and also can support multiple pointer events. Saying that I have not looked at multi-tap functionality yet e.g pinch and so may require some work.

FlexInputHelper has been enhanced to support IE10. As you know IE10 uses an inbetween specification of the flex model. The big differences are in IE10 flex items by default have a flex of 0 1 0%. I've changed it so all items will have a flex of 0 1 auto the default for the new standard.

However in IE10 if you set -ms-flex: 1 by default it will set the flex as 1 0 auto

For the new standard -webkit-flex: 1 by default will set the flex to 1 1 0%

Hence I've changed the FlexInputHelper for IE10 to copy the new standard.

I've also fixed the emulation of masked images. I was seeing images disappear/reappear in IE10. Others reported similar issues on the user group on any client that did not support webkit masks (e.g. android < 4.4). It needed a callback to wait for the image to be loaded before transforming it.

IMPORTANT: Due to IE10 not dynamically applying the settings correctly when adding the meta tag viewport you have to add it yourself in the index.html file.

There is still an issue with state management. When doing history.back to the index.html page it looks like ie10 refreshes the entire page.

On windows phone if you go to about page and then hit back it jumps to the previous web page before you loaded showcase.

Cheers