### PR TITLE
Fix for black background gradient not being applied on Android.

### DIFF
--- a/src/main/java/com/googlecode/mgwt/ui/client/theme/platform/main/main.css
+++ b/src/main/java/com/googlecode/mgwt/ui/client/theme/platform/main/main.css
@@ -7,6 +7,7 @@
 @if mgwt.os android {
   body {
 	  background-attachment: fixed;
+	  background-image: literal('-webkit-gradient(linear, left top, left bottom, from(#000000), to(rgb(46, 54, 60)))');
 	  color: white;
   }
 


### PR DESCRIPTION
The linear gradient is never applied on Chrome 39 both on the desktop and
Android browser when mgwt.os is set to 'android'. The result is the background
stays the default #ECEBF1 color with white text making it difficult to read.

I'm not sure if the body::before pseudo element is still needed for legacy
reasons, however, the submitted change does work in Chrome 39.