### PR TITLE
Fix the issue with big numbers in MDoubleBox

### DIFF
--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/input/MDoubleBox.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/input/MDoubleBox.java
@@ -15,8 +15,13 @@
  */
 package com.googlecode.mgwt.ui.client.widget.input;
 
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.event.shared.HandlerManager;
-import com.google.gwt.user.client.ui.DoubleBox;
+import com.google.gwt.i18n.client.NumberFormat;
+import com.google.gwt.text.client.DoubleParser;
+import com.google.gwt.text.shared.AbstractRenderer;
+import com.google.gwt.text.shared.Renderer;
+import com.google.gwt.user.client.ui.ValueBox;
 
 import com.googlecode.mgwt.ui.client.widget.base.MValueBoxBase;
 
@@ -27,11 +32,13 @@ import com.googlecode.mgwt.ui.client.widget.base.MValueBoxBase;
  */
 public class MDoubleBox extends MValueBoxBase<Double> {
 
-  private static class SDoubleBox extends DoubleBox implements HasSource {
+  private static class SDoubleBox extends ValueBox<Double> implements HasSource {
 
     private Object source;
 
     public SDoubleBox() {
+      super(Document.get().createTextInputElement(), DoubleRenderer.instance(),
+            DoubleParser.instance());
       setStylePrimaryName("gwt-DoubleBox");
     }
 
@@ -53,5 +60,31 @@ public class MDoubleBox extends MValueBoxBase<Double> {
     super(appearance, new SDoubleBox());
     impl.setType(box.getElement(), "number");
     addStyleName(appearance.css().textBox());
+  }
+
+  public static class DoubleRenderer extends AbstractRenderer<Double> {
+    private static DoubleRenderer INSTANCE;
+    private static NumberFormat formatter = NumberFormat.getFormat("#.###");
+
+    /**
+     * Returns the instance.
+     */
+    public static Renderer<Double> instance() {
+      if (INSTANCE == null) {
+        INSTANCE = new DoubleRenderer();
+      }
+      return INSTANCE;
+    }
+
+    protected DoubleRenderer() {
+    }
+
+    public String render(Double object) {
+      if (object == null) {
+        return "";
+      }
+
+      return formatter.format(object);
+    }
   }
 }


### PR DESCRIPTION
There is an [issue](http://stackoverflow.com/questions/29651721/setvalue-in-mdoublebox-fails-with-grouping-decimal-separators/29662401) with `MDoubleBox`. When using big numbers (fe: 1024.54), the default double renderer try to set the string "1,024.54" into the `<input type="number">`. But the character "," is not valid for a `<input type="number">` and so nothing is displayed.

This PR uses a different double renderer to render the value without the "," character.

Downfall: we loose the different localisation formatting. But since they are not supported in a `<input type="number">`, I don't think this is a big issue.