### PR TITLE
Bug Fix of LongTapRecognizer

### DIFF
--- a/src/main/java/com/googlecode/mgwt/dom/client/recognizer/longtap/LongTapRecognizer.java
+++ b/src/main/java/com/googlecode/mgwt/dom/client/recognizer/longtap/LongTapRecognizer.java
@@ -43,7 +43,7 @@ public class LongTapRecognizer implements TouchHandler {
 
   protected enum State {
     INVALID, READY, FINGERS_DOWN, FINGERS_UP, WAITING
-  };
+  }
 
   protected State state;
   private final HasHandlers source;
@@ -231,6 +231,7 @@ public class LongTapRecognizer implements TouchHandler {
   protected void reset() {
     state = State.READY;
     touchCount = 0;
+    startPositions = CollectionFactory.constructArray();
   }
 
   // Visible for testing


### PR DESCRIPTION
The reset() method did not reset the startPositions array which is used in onTouchMove to detect moves.

Thus old long taps did influence the move detection of new long tap, thereby invalidating new long taps at other different positions.