### PR TITLE
OverlayMenu display style property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <name>mgwt</name>
 
   <properties>
-    <gwtversion>2.6.1</gwtversion>
+    <gwtversion>2.7.0</gwtversion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/menu/overlay/OverlayMenu.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/menu/overlay/OverlayMenu.java
@@ -131,6 +131,7 @@ public class OverlayMenu extends Composite {
           if (showNavHandler != null) {
             showNavHandler.removeHandler();
             showNavHandler = null;
+            nav.getElement().getStyle().clearDisplay();
           }
         }
       }, TransitionEndEvent.getType());


### PR DESCRIPTION
OverlayMenu did not clear the ‘display’ style property in the TransitionEndHandler when the menu was show programmatically (i.e. with a overlayMenu.showNav(true);).
The ‘display’ property is correctly set to ‘block’ when the showing transaction starts, but if not cleared, the menu content is not visible.

gwtversion also set from 2.6.1 to 2.7.0 in pom.xml
