### PR TITLE
OverlayMenu did not clear the ‘display’ style property in the

### DIFF
--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/menu/overlay/OverlayMenu.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/menu/overlay/OverlayMenu.java
@@ -131,6 +131,7 @@ public class OverlayMenu extends Composite {
           if (showNavHandler != null) {
             showNavHandler.removeHandler();
             showNavHandler = null;
+            nav.getElement().getStyle().clearDisplay();
           }
         }
       }, TransitionEndEvent.getType());


### PR DESCRIPTION
OverlayMenu did not clear the ‘display’ style property in the TransitionEndHandler when the menu was show programmatically (i.e. with a overlayMenu.showNav(true);).
The ‘display’ property is correctly set to ‘block’ when the showing transaction starts, but if not cleared, the menu content is not visible.