### PR TITLE
Remove duplicate method setSupportCarouselIndicatorTap(boolean)

### DIFF
--- a/src/main/java/com/googlecode/mgwt/ui/client/widget/carousel/Carousel.java
+++ b/src/main/java/com/googlecode/mgwt/ui/client/widget/carousel/Carousel.java
@@ -501,16 +501,6 @@ public class Carousel extends Composite implements HasWidgets, HasSelectionHandl
         carouselIndicatorContainer.setHandleTapEvent(supportCarouselIndicatorTap);
     }
   }
-
-  /**
-   * Set if carousel indicator support tap events.
-   */
-  public void setSupportCarouselIndicatorTap(boolean supportCarouselIndicatorTap) {
-    if (supportCarouselIndicatorTap != this.supportCarouselIndicatorTap) {
-        this.supportCarouselIndicatorTap = supportCarouselIndicatorTap;
-        carouselIndicatorContainer.setHandleTapEvent(supportCarouselIndicatorTap);
-    }
-  }
   
   public ScrollPanel getScrollPanel() {
     return scrollPanel;


### PR DESCRIPTION
While fixing the merge conflicts likely resulting from commit 34bbbf2fd742637782cadf41ee821476c510f751 and the procedding pull request this duplicate method got missed.